### PR TITLE
Element search history

### DIFF
--- a/lib/kitchen/element_base.rb
+++ b/lib/kitchen/element_base.rb
@@ -13,6 +13,7 @@ module Kitchen
     attr_reader :document
     attr_reader :short_type
     attr_reader :enumerator_class
+    attr_accessor :css_or_xpath_that_found_me
 
     # @!method name
     #   Get the element name (the tag)
@@ -110,6 +111,10 @@ module Kitchen
       @ancestors[ancestor.type] = ancestor
     end
 
+    def ancestor_elements
+      @ancestors.values.map(&:element)
+    end
+
     def count_as_descendant
       @ancestors.each_pair do |type, ancestor|
         @counts_in[type] = ancestor.increment_descendant_count(short_type)
@@ -130,6 +135,11 @@ module Kitchen
 
     def number_of_sub_elements_already_counted(css_or_xpath)
       @css_or_xpath_that_has_been_counted[css_or_xpath] || 0
+    end
+
+    def search_history
+      history = ancestor_elements.map(&:css_or_xpath_that_found_me) + [css_or_xpath_that_found_me]
+      history.compact.join(" ")
     end
 
     def search(*selector_or_xpath_args)

--- a/lib/kitchen/element_enumerator_factory.rb
+++ b/lib/kitchen/element_enumerator_factory.rb
@@ -19,10 +19,11 @@ module Kitchen
           # define a dynamic short type based on the search css/xpath.
           sub_element =
             sub_element_class == Element ?
-              sub_element_class.new(node: sub_node, document: element.document,
+              sub_element_class.new(node: sub_node,
+                                    document: element.document,
                                     short_type: Utils.search_path_to_type(css_or_xpath)) :
-              sub_element_class.new(node: sub_node, document: element.document)
-
+              sub_element_class.new(node: sub_node,
+                                    document: element.document)
 
           # If the provided `css_or_xpath` has already been counted, we need to uncount
           # them on the ancestors so that when they are counted again below, the counts
@@ -38,9 +39,15 @@ module Kitchen
             end
           end
 
+          # Record this sub element's ancestors and increment their descendant counts
           sub_element.add_ancestors(grand_ancestors, parent_ancestor)
           sub_element.count_as_descendant
 
+          # Remember how this sub element was found so can trace search history given
+          # any element.
+          sub_element.css_or_xpath_that_found_me = css_or_xpath
+
+          # Count runs through this loop for below
           num_sub_elements += 1
 
           # Mark the location so that if there's an error we can show the developer where.

--- a/lib/kitchen/page_element.rb
+++ b/lib/kitchen/page_element.rb
@@ -15,10 +15,6 @@ module Kitchen
       first!("./*[@data-type = 'document-title']")
     end
 
-    def terms
-      TermElementEnumerator.within(element: self)
-    end
-
     def is_introduction?
       has_class?("introduction")
     end

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -179,7 +179,13 @@ RSpec.describe Kitchen::Element do
       inner = element_1.search("p").search("span").first
       expect(inner.ancestor("p").id).to eq "pId"
     end
+  end
 
+  context "search history" do
+    it "returns search history" do
+      inner = element_1.search("#pId").search("span").first
+      expect(inner.search_history).to eq "#pId span"
+    end
   end
 
 end


### PR DESCRIPTION
Given an element, call `.search_history` on it to see how it was traversed to.