### PR TITLE
Factory instances

### DIFF
--- a/lib/kitchen.rb
+++ b/lib/kitchen.rb
@@ -19,6 +19,7 @@ require_all("kitchen/mixins")
 require "kitchen/utils"
 require "kitchen/errors"
 require "kitchen/ancestor"
+require "kitchen/search_history"
 require "kitchen/element_enumerator"
 require "kitchen/element_enumerator_factory"
 require "kitchen/page_element_enumerator"

--- a/lib/kitchen/chapter_element_enumerator.rb
+++ b/lib/kitchen/chapter_element_enumerator.rb
@@ -1,12 +1,12 @@
 module Kitchen
   class ChapterElementEnumerator < ElementEnumerator
 
-    def self.within(element:, css_or_xpath: nil)
-      ElementEnumeratorFactory.within(new_enumerator_class: self,
-                                      element: element,
-                                      css_or_xpath: css_or_xpath,
-                                      default_css_or_xpath: "div[data-type='chapter']", # TODO element.document.selectors.chapter
-                                      sub_element_class: ChapterElement)
+    def self.factory
+      ElementEnumeratorFactory.new(
+        default_css_or_xpath: "div[data-type='chapter']", # TODO element.document.selectors.chapter
+        sub_element_class: ChapterElement,
+        enumerator_class: self
+      )
     end
 
   end

--- a/lib/kitchen/element_base.rb
+++ b/lib/kitchen/element_base.rb
@@ -145,11 +145,9 @@ module Kitchen
     def search(*selector_or_xpath_args)
       block_error_if(block_given?)
 
-      ElementEnumeratorFactory.within(
-        new_enumerator_class: ElementEnumerator,
+      ElementEnumerator.factory.within(
         element: self,
-        css_or_xpath: nil,
-        default_css_or_xpath: selector_or_xpath_args,
+        css_or_xpath: selector_or_xpath_args,
       )
     end
 

--- a/lib/kitchen/element_base.rb
+++ b/lib/kitchen/element_base.rb
@@ -145,10 +145,7 @@ module Kitchen
     def search(*selector_or_xpath_args)
       block_error_if(block_given?)
 
-      ElementEnumerator.factory.within(
-        element: self,
-        css_or_xpath: selector_or_xpath_args,
-      )
+      ElementEnumerator.factory.build_within(self, css_or_xpath: selector_or_xpath_args)
     end
 
     # Yields and returns the first child element that matches the provided

--- a/lib/kitchen/element_enumerator.rb
+++ b/lib/kitchen/element_enumerator.rb
@@ -50,10 +50,9 @@ module Kitchen
       enumerator_class.factory.build_within(self, css_or_xpath: css_or_xpath)
     end
 
-    def first!(missing_message: nil)
-      # debugger
-      # TODO would be cool to record the CSS in the enumerator constructor so can say "no first blah" here
-      first || raise(RecipeError, missing_message || "Could not return a first result")
+    def first!(missing_message: "Could not return a first result")
+      first || raise(RecipeError, "#{missing_message} matching #{search_history.latest} " \
+                                  "inside #{search_history.upstream}")
     end
 
     # Removes enumerated elements from their parent and places them on the specified clipboard

--- a/lib/kitchen/element_enumerator.rb
+++ b/lib/kitchen/element_enumerator.rb
@@ -1,47 +1,57 @@
 module Kitchen
   class ElementEnumerator < Enumerator
 
+    def initialize(size=nil, css_or_xpath: nil, upstream_enumerator: nil)
+      @css_or_xpath = css_or_xpath
+      @upstream_enumerator = upstream_enumerator
+      super(size)
+    end
+
+    def search_history
+      (@upstream_enumerator&.search_history || SearchHistory.empty).add(@css_or_xpath)
+    end
+
     def terms(css_or_xpath=nil, &block)
-      chain_to(enumerator_class: TermElementEnumerator, css_or_xpath: css_or_xpath, &block)
+      chain_to(TermElementEnumerator, css_or_xpath: css_or_xpath, &block)
     end
 
     def pages(css_or_xpath=nil, &block)
-      chain_to(enumerator_class: PageElementEnumerator, css_or_xpath: css_or_xpath, &block)
+      chain_to(PageElementEnumerator, css_or_xpath: css_or_xpath, &block)
     end
 
     def chapters(css_or_xpath=nil, &block)
-      chain_to(enumerator_class: ChapterElementEnumerator, css_or_xpath: css_or_xpath, &block)
+      chain_to(ChapterElementEnumerator, css_or_xpath: css_or_xpath, &block)
     end
 
     # use block_error_if
     def figures(css_or_xpath=nil, &block)
-      chain_to(enumerator_class: FigureElementEnumerator, css_or_xpath: css_or_xpath, &block)
+      chain_to(FigureElementEnumerator, css_or_xpath: css_or_xpath, &block)
     end
 
     def notes(css_or_xpath=nil, &block)
-      chain_to(enumerator_class: NoteElementEnumerator, css_or_xpath: css_or_xpath, &block)
+      chain_to(NoteElementEnumerator, css_or_xpath: css_or_xpath, &block)
     end
 
     def tables(css_or_xpath=nil, &block)
-      chain_to(enumerator_class: TableElementEnumerator, css_or_xpath: css_or_xpath, &block)
+      chain_to(TableElementEnumerator, css_or_xpath: css_or_xpath, &block)
     end
 
     def examples(css_or_xpath=nil, &block)
-      ExampleElementEnumerator.factory.build_within(self, css_or_xpath: css_or_xpath)
-      # chain_to(enumerator_class: ExampleElementEnumerator, css_or_xpath: css_or_xpath, &block)
+      chain_to(ExampleElementEnumerator, css_or_xpath: css_or_xpath, &block)
     end
 
     def search(css_or_xpath=nil, &block)
-      chain_to(enumerator_class: ElementEnumerator, css_or_xpath: css_or_xpath, &block)
+      chain_to(ElementEnumerator, css_or_xpath: css_or_xpath, &block)
     end
 
-    def chain_to(enumerator_class:, css_or_xpath: nil, &block)
+    def chain_to(enumerator_class, css_or_xpath: nil, &block)
       raise(RecipeError, "Did you forget a `.each` call on this enumerator?") if block_given?
 
       enumerator_class.factory.build_within(self, css_or_xpath: css_or_xpath)
     end
 
     def first!(missing_message: nil)
+      # debugger
       # TODO would be cool to record the CSS in the enumerator constructor so can say "no first blah" here
       first || raise(RecipeError, missing_message || "Could not return a first result")
     end

--- a/lib/kitchen/element_enumerator.rb
+++ b/lib/kitchen/element_enumerator.rb
@@ -27,7 +27,8 @@ module Kitchen
     end
 
     def examples(css_or_xpath=nil, &block)
-      chain_to(enumerator_class: ExampleElementEnumerator, css_or_xpath: css_or_xpath, &block)
+      ExampleElementEnumerator.factory.build_within(self, css_or_xpath: css_or_xpath)
+      # chain_to(enumerator_class: ExampleElementEnumerator, css_or_xpath: css_or_xpath, &block)
     end
 
     def search(css_or_xpath=nil, &block)
@@ -37,7 +38,7 @@ module Kitchen
     def chain_to(enumerator_class:, css_or_xpath: nil, &block)
       raise(RecipeError, "Did you forget a `.each` call on this enumerator?") if block_given?
 
-      enumerator_class.factory.chain_to(other_enumerator: self, css_or_xpath: css_or_xpath)
+      enumerator_class.factory.build_within(self, css_or_xpath: css_or_xpath)
     end
 
     def first!(missing_message: nil)

--- a/lib/kitchen/element_enumerator.rb
+++ b/lib/kitchen/element_enumerator.rb
@@ -37,14 +37,12 @@ module Kitchen
     def chain_to(enumerator_class:, css_or_xpath: nil, &block)
       raise(RecipeError, "Did you forget a `.each` call on this enumerator?") if block_given?
 
-      ElementEnumeratorFactory.chained_to_other(new_enumerator_class: enumerator_class,
-                                                other_enumerator: self,
-                                                css_or_xpath: css_or_xpath)
+      enumerator_class.factory.chain_to(other_enumerator: self, css_or_xpath: css_or_xpath)
     end
 
-    def first!
+    def first!(missing_message: nil)
       # TODO would be cool to record the CSS in the enumerator constructor so can say "no first blah" here
-      first || raise(RecipeError, "Could not return a first result")
+      first || raise(RecipeError, missing_message || "Could not return a first result")
     end
 
     # Removes enumerated elements from their parent and places them on the specified clipboard
@@ -89,12 +87,11 @@ module Kitchen
       self.map(&:to_s).join("")
     end
 
-    def self.within(element:, css_or_xpath:)
-      ElementEnumeratorFactory.within(new_enumerator_class: self,
-                                      element: element,
-                                      css_or_xpath: css_or_xpath,
-                                      default_css_or_xpath: "*",
-                                      sub_element_class: Element)
+    def self.factory
+      ElementEnumeratorFactory.new(
+        sub_element_class: Element,
+        enumerator_class: self
+      )
     end
 
   end

--- a/lib/kitchen/element_enumerator_factory.rb
+++ b/lib/kitchen/element_enumerator_factory.rb
@@ -32,7 +32,7 @@ module Kitchen
     protected
 
     def build_within_element(element, css_or_xpath:)
-      enumerator_class.new do |block|
+      enumerator_class.new(css_or_xpath: css_or_xpath) do |block|
         grand_ancestors = element.ancestors
         parent_ancestor = Ancestor.new(element)
 
@@ -89,7 +89,7 @@ module Kitchen
     def build_within_other_enumerator(other_enumerator, css_or_xpath:)
       # Return a new enumerator instance that internally iterates over `other_enumerator`
       # running a new enumerator for each element returned by that other enumerator.
-      enumerator_class.new do |block|
+      enumerator_class.new(css_or_xpath: css_or_xpath, upstream_enumerator: other_enumerator) do |block|
         other_enumerator.each do |element|
           build_within_element(element, css_or_xpath: css_or_xpath).each do |sub_element|
             block.yield(sub_element)

--- a/lib/kitchen/example_element_enumerator.rb
+++ b/lib/kitchen/example_element_enumerator.rb
@@ -1,12 +1,12 @@
 module Kitchen
   class ExampleElementEnumerator < ElementEnumerator
 
-    def self.within(element:, css_or_xpath: nil)
-      ElementEnumeratorFactory.within(new_enumerator_class: self,
-                                      element: element,
-                                      css_or_xpath: css_or_xpath,
-                                      default_css_or_xpath: "div[data-type='example']",
-                                      sub_element_class: ExampleElement)
+    def self.factory
+      ElementEnumeratorFactory.new(
+        default_css_or_xpath: "div[data-type='example']", # TODO element.document.selectors.example
+        sub_element_class: ExampleElement,
+        enumerator_class: self
+      )
     end
 
   end

--- a/lib/kitchen/figure_element_enumerator.rb
+++ b/lib/kitchen/figure_element_enumerator.rb
@@ -1,12 +1,12 @@
 module Kitchen
   class FigureElementEnumerator < ElementEnumerator
 
-    def self.within(element:, css_or_xpath: nil)
-      ElementEnumeratorFactory.within(new_enumerator_class: self,
-                                      element: element,
-                                      css_or_xpath: css_or_xpath,
-                                      default_css_or_xpath: "figure", # TODO element.document.selectors.figure
-                                      sub_element_class: FigureElement)
+    def self.factory
+      ElementEnumeratorFactory.new(
+        default_css_or_xpath: "figure", # TODO get from config?
+        sub_element_class: FigureElement,
+        enumerator_class: self
+      )
     end
 
   end

--- a/lib/kitchen/note_element_enumerator.rb
+++ b/lib/kitchen/note_element_enumerator.rb
@@ -1,12 +1,12 @@
 module Kitchen
   class NoteElementEnumerator < ElementEnumerator
 
-    def self.within(element:, css_or_xpath: nil)
-      ElementEnumeratorFactory.within(new_enumerator_class: self,
-                                      element: element,
-                                      css_or_xpath: css_or_xpath,
-                                      default_css_or_xpath: "div[data-type='note']", # TODO element.document.selectors.note
-                                      sub_element_class: NoteElement)
+    def self.factory
+      ElementEnumeratorFactory.new(
+        default_css_or_xpath: "div[data-type='note']", # TODO get from config?
+        sub_element_class: NoteElement,
+        enumerator_class: self
+      )
     end
 
   end

--- a/lib/kitchen/page_element_enumerator.rb
+++ b/lib/kitchen/page_element_enumerator.rb
@@ -1,12 +1,12 @@
 module Kitchen
   class PageElementEnumerator < ElementEnumerator
 
-    def self.within(element:, css_or_xpath: nil)
-      ElementEnumeratorFactory.within(new_enumerator_class: self,
-                                      element: element,
-                                      css_or_xpath: css_or_xpath,
-                                      default_css_or_xpath: "div[data-type='page']", # TODO element.document.selectors.page
-                                      sub_element_class: PageElement)
+    def self.factory
+      ElementEnumeratorFactory.new(
+        default_css_or_xpath: "div[data-type='page']", # TODO get from config?
+        sub_element_class: PageElement,
+        enumerator_class: self
+      )
     end
 
   end

--- a/lib/kitchen/search_history.rb
+++ b/lib/kitchen/search_history.rb
@@ -1,0 +1,23 @@
+module Kitchen
+  class SearchHistory
+
+    def self.empty
+      new
+    end
+
+    def add(css_or_xpath)
+      self.class.new(@items.dup + [css_or_xpath])
+    end
+
+    def to_s(missing_string="?")
+      @items.map{|item| item.nil? ? missing_string : item}.join(" ")
+    end
+
+    protected
+
+    def initialize(items=[])
+      @items = items
+    end
+
+  end
+end

--- a/lib/kitchen/search_history.rb
+++ b/lib/kitchen/search_history.rb
@@ -1,23 +1,33 @@
 module Kitchen
   class SearchHistory
+    attr_reader :latest
+    attr_reader :upstream
 
     def self.empty
       new
     end
 
     def add(css_or_xpath)
-      self.class.new(@items.dup + [css_or_xpath])
+      self.class.new(self, css_or_xpath.nil? ? nil : [css_or_xpath].join(", "))
     end
 
     def to_s(missing_string="?")
-      @items.map{|item| item.nil? ? missing_string : item}.join(" ")
+      to_a.map{|item| "[#{item || missing_string}]"}.join(" ")
+    end
+
+    def to_a
+      empty? ? [] : [upstream&.to_a || [], latest].flatten
+    end
+
+    def empty?
+      upstream.nil? && latest.nil?
     end
 
     protected
 
-    def initialize(items=[])
-      @items = items
+    def initialize(upstream=nil, latest=nil)
+      @upstream = upstream
+      @latest = latest
     end
-
   end
 end

--- a/lib/kitchen/table_element_enumerator.rb
+++ b/lib/kitchen/table_element_enumerator.rb
@@ -1,12 +1,12 @@
 module Kitchen
   class TableElementEnumerator < ElementEnumerator
 
-    def self.within(element:, css_or_xpath: nil)
-      ElementEnumeratorFactory.within(new_enumerator_class: self,
-                                      element: element,
-                                      css_or_xpath: css_or_xpath,
-                                      default_css_or_xpath: "table", # TODO element.document.selectors.table
-                                      sub_element_class: TableElement)
+    def self.factory
+      ElementEnumeratorFactory.new(
+        default_css_or_xpath: "table", # TODO get from config?
+        sub_element_class: TableElement,
+        enumerator_class: self
+      )
     end
 
   end

--- a/lib/kitchen/term_element_enumerator.rb
+++ b/lib/kitchen/term_element_enumerator.rb
@@ -1,12 +1,12 @@
 module Kitchen
   class TermElementEnumerator < ElementEnumerator
 
-    def self.within(element:, css_or_xpath: nil)
-      ElementEnumeratorFactory.within(new_enumerator_class: self,
-                                      element: element,
-                                      css_or_xpath: css_or_xpath,
-                                      default_css_or_xpath: "span[data-type='term']", # TODO element.document.selectors.term
-                                      sub_element_class: TermElement)
+    def self.factory
+      ElementEnumeratorFactory.new(
+        default_css_or_xpath: "span[data-type='term']", # TODO get from config?
+        sub_element_class: TermElement,
+        enumerator_class: self
+      )
     end
 
   end

--- a/spec/element_enumerator_spec.rb
+++ b/spec/element_enumerator_spec.rb
@@ -17,6 +17,22 @@ RSpec.describe Kitchen::ElementEnumerator do
 
   let(:element_1_enumerator) { described_class.new {|block| block.yield(element_1)} }
 
+  let(:element_2) do
+    new_element(
+      <<~HTML
+        <div id="divId">
+          <div class="foo">
+            <p id="pId">
+              <span>Blah</span>
+            </p>
+          </div>
+        </div>
+      HTML
+    )
+  end
+
+  let(:element_2_enumerator) { described_class.new {|block| block.yield(element_2)} }
+
   it "iterates over one element" do
     expect(element_1_enumerator.map(&:name)).to eq %w(div)
   end
@@ -78,6 +94,13 @@ RSpec.describe Kitchen::ElementEnumerator do
       enumerator.copy(to: clipboard)
       expect(element_1.to_s).to eq original_element_1_string
       expect(clipboard.paste).to match(/id1.*id2[^3]*id4/)
+    end
+  end
+
+  context "#search_history" do
+    it "works" do
+      chained_enumerator = element_2_enumerator.search(".foo").search("#pId").search("span")
+      expect(chained_enumerator.search_history.to_s).to eq "? .foo #pId span"
     end
   end
 

--- a/spec/element_enumerator_spec.rb
+++ b/spec/element_enumerator_spec.rb
@@ -100,7 +100,15 @@ RSpec.describe Kitchen::ElementEnumerator do
   context "#search_history" do
     it "works" do
       chained_enumerator = element_2_enumerator.search(".foo").search("#pId").search("span")
-      expect(chained_enumerator.search_history.to_s).to eq "? .foo #pId span"
+      expect(chained_enumerator.search_history.to_s).to eq "[?] [.foo] [#pId] [span]"
+    end
+  end
+
+  context "#first!" do
+    it "gives a meaningful error message when it bombs" do
+      expect{
+        element_2_enumerator.search(".foo").search("#blah").first!
+      }.to raise_error(/not return a first result matching #blah inside .*\.foo/)
     end
   end
 

--- a/spec/search_history_spec.rb
+++ b/spec/search_history_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+RSpec.describe Kitchen::SearchHistory do
+  context "empty" do
+    it "converts to an empty array" do
+      expect(described_class.empty.to_a).to eq []
+    end
+  end
+
+  context "#to_s" do
+    it "works" do
+      expect(described_class.empty.add(nil).add("foo").add([".blah",".bar"]).to_s).to eq "[?] [foo] [.blah, .bar]"
+    end
+  end
+end


### PR DESCRIPTION
Change from class methods to instance methods in the ElementEnumeratorFactory.  Cleans up the code and enables easier tracking of nested enumerator search history.

Use that search history to give good error messages when `first!` bombs.