### PR TITLE
remove gemspec exclusion from rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,8 +23,6 @@ Metrics/MethodLength:
 
 Metrics/BlockLength:
   CountAsOne: ['heredoc']
-  Exclude:
-    - *.gemspec
 
 Metrics/ModuleLength:
   CountAsOne: ['heredoc']


### PR DESCRIPTION
[Rubocop by default](https://github.com/rubocop-hq/rubocop/blob/master/config/default.yml#L2237-L2238) disables the "BlockLength" metric for a gem's `*.gemspec` file.  However, in vscode, it doesn't ignore it.  I tried to add the lines this PR removes to make it ignore it, which appeared to work, but really what it did was just break Rubocop everywhere!

So get rid of these lines and later figure out how to make vscode's rubocop usage ignore the gemspec.

