### PR TITLE
Add lefthook pre-push hook to run Rubocop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,4 +116,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.2.6
+   2.2.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (1.3.0)
       parser (>= 2.7.1.5)
+    rubocop-rake (0.5.1)
+      rubocop
     rubocop-rspec (2.1.0)
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
@@ -109,8 +111,9 @@ DEPENDENCIES
   rake (~> 12.0)
   rspec (~> 3.0)
   rubocop
+  rubocop-rake
   rubocop-rspec
   yard
 
 BUNDLED WITH
-   2.2.4
+   2.2.6

--- a/README.md
+++ b/README.md
@@ -631,6 +631,12 @@ or we can disable or change global settings in the `.rubocop.yml` file.
 
 Rubocop is setup to run within the VSCode dev container (see above).
 
+The [lefthook](https://github.com/Arkweid/lefthook) is included in the Docker build.  When you push your code to GitHub, lefthook runs Rubocop on all the files you have changed.  It won't let you push if you have Rubocop errors.  You'll have to fix the errors or make changes to the `.rubocop.yml` files to bypass the errors.  You can also run lefthook directly with
+
+```bash
+$ /code> lefthook run pre-push
+```
+
 #### Misc References
 
 * https://marketplace.visualstudio.com/items?itemName=castwide.solargraph

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,9 +26,9 @@ RUN wget -O ~/vsls-reqs https://aka.ms/vsls-linux-prereq-script && chmod +x ~/vs
 WORKDIR /code
 COPY . /code/
 
-RUN gem install solargraph && \
+RUN gem install bundler --no-document --version $bundler_version && \
+    gem install solargraph && \
     gem install lefthook && \
-    gem install bundler --no-document --version $bundler_version && \
     bundle config set no-cache 'true' && \
     bundle config set silence_root_warning 'true' && \
     bundle install && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,7 @@ WORKDIR /code
 COPY . /code/
 
 RUN gem install solargraph && \
+    gem install lefthook && \
     gem install bundler --no-document --version $bundler_version && \
     bundle config set no-cache 'true' && \
     bundle config set silence_root_warning 'true' && \

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,6 @@
+pre-push:
+  commands:
+    rubocop:
+      files: git diff --name-only master
+      glob: "*.rb"
+      run: bundle exec rubocop {files} --disable-pending-cops

--- a/openstax_kitchen.gemspec
+++ b/openstax_kitchen.gemspec
@@ -38,5 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rainbow'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-rspec'
+  spec.add_development_dependency 'rubocop-rake'
   spec.add_development_dependency 'yard'
 end

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -26,3 +26,8 @@ RSpec/FilePath:
 
 RSpec/ExampleLength:
   Enabled: false
+
+# JP likes to say `expect().to receive(:blah)` before things happen rather than
+# doing things and saying `expect().to have_received(:blah)` afterwards
+RSpec/MessageSpies:
+  EnforcedStyle: receive

--- a/spec/recipe_spec.rb
+++ b/spec/recipe_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Kitchen::Recipe do
   let(:dummy_document) { Kitchen::Document.new(nokogiri_document: nil) }
 
-  context '#initialize' do
+  describe '#initialize' do
     it 'requires a block' do
       expect { described_class.new }.to raise_error(Kitchen::RecipeError)
     end
@@ -14,7 +16,7 @@ RSpec.describe Kitchen::Recipe do
     expect(recipe.source_location).to eq __FILE__
   end
 
-  context '#document=' do
+  describe '#document=' do
     it 'works for a Kitchen::Document' do
       expect { (described_class.new {}).document = dummy_document }.not_to raise_error
     end
@@ -24,7 +26,7 @@ RSpec.describe Kitchen::Recipe do
     end
   end
 
-  context '#bake' do
+  describe '#bake' do
     it 'calls the recipe block with the document' do
       expect(target = double).to receive(:foo).with(nil)
       recipe = described_class.new do |document|
@@ -38,14 +40,14 @@ RSpec.describe Kitchen::Recipe do
     end
 
     it 'prints ElementNotFoundError' do
-      expect_error_print_and_exit_on_bake(error_class: Kitchen::RecipeError)
+      expect_error_print_and_exit_on_bake(error_class: Kitchen::ElementNotFoundError)
     end
 
     it 'prints Nokogiri::CSS::SyntaxError' do
       expect_error_print_and_exit_on_bake(error_class: Nokogiri::CSS::SyntaxError)
     end
 
-    context 'ArgumentError' do
+    context 'when there is an ArgumentError' do
       it 'prints when a callstack location matches the source location' do
         expect_error_print_and_exit_on_bake(error_class: ArgumentError)
       end
@@ -55,7 +57,7 @@ RSpec.describe Kitchen::Recipe do
       end
     end
 
-    context 'NoMethodError' do
+    context 'when there is an NoMethodError' do
       it 'prints when a callstack location matches the source location' do
         expect_error_print_and_exit_on_bake(error_class: NoMethodError)
       end
@@ -65,7 +67,7 @@ RSpec.describe Kitchen::Recipe do
       end
     end
 
-    context 'NameError' do
+    context 'when there is an NameError' do
       it 'prints when a callstack location matches the source location' do
         expect_error_print_and_exit_on_bake(error_class: NameError)
       end
@@ -80,12 +82,12 @@ RSpec.describe Kitchen::Recipe do
     recipe_block = proc { raise error_class }
     allow(recipe_block).to receive(:source_location).and_return(['foobar'])
     expect(Kitchen::Debug).not_to receive(:print_recipe_error)
-    expect { (described_class.new &recipe_block).bake }.to raise_error(error_class)
+    expect { described_class.new(&recipe_block).bake }.to raise_error(error_class)
   end
 
   def expect_error_print_and_exit_on_bake(error_class:)
     recipe_block = proc { raise error_class }
     expect(Kitchen::Debug).to receive(:print_recipe_error)
-    expect { (described_class.new &recipe_block).bake }.to raise_error(SystemExit)
+    expect { described_class.new(&recipe_block).bake }.to raise_error(SystemExit)
   end
 end


### PR DESCRIPTION
Adds [lefthook](https://github.com/Arkweid/lefthook) to run Rubocop right before we push to GitHub.  If there are Rubocop errors in your modified files, you'll get errors and will not be able to push.

If you want to run lefthook directly without having to push you can do `lefthook run pre-push`

```
@76dbc6533f47:/code] 5s # git push origin lefthook
/usr/local/bundle/gems/lefthook-0.7.2/libexec/lefthook-linux run pre-push origin git@github.com:openstax/kitchen.git
Lefthook v0.7.2
RUNNING HOOKS GROUP: pre-push

  EXECUTE > rubocop
Inspecting 1 file
.

1 file inspected, no offenses detected

SUMMARY: (done in 1.38 seconds)
✔️  rubocop
Everything up-to-date
```

Fixes #80 