### PR TITLE
replace terms with i18n

### DIFF
--- a/lib/kitchen/directions/bake_chapter_introductions.rb
+++ b/lib/kitchen/directions/bake_chapter_introductions.rb
@@ -32,7 +32,7 @@ module Kitchen
             <<~HTML
               <div class="intro-body">
                 <div class="os-chapter-outline">
-                  <h3 class="os-title">Chapter Outline</h3>
+                  <h3 class="os-title">#{I18n.t(:chapter_outline)}</h3>
                   #{outline_items_html}
                 </div>
                 <div class="intro-text">

--- a/lib/kitchen/directions/bake_chapter_title/v1.rb
+++ b/lib/kitchen/directions/bake_chapter_title/v1.rb
@@ -11,7 +11,7 @@ module Kitchen::Directions::BakeChapterTitle
       heading[:id] = "chapTitle#{chapter.count_in(:book)}"
       heading.replace_children(with:
         <<~HTML
-          <span class="os-part-text">Chapter </span>
+          <span class="os-part-text">#{I18n.t(:chapter)} </span>
           <span class="os-number">#{chapter.count_in(:book)}</span>
           <span class="os-divider"> </span>
           <span data-type="" itemprop="" class="os-text">#{heading.text}</span>

--- a/lib/kitchen/directions/bake_toc.rb
+++ b/lib/kitchen/directions/bake_toc.rb
@@ -14,7 +14,7 @@ module Kitchen
         end.compact.join("\n")
 
         book.first!('nav').replace_children(with: <<~HTML
-          <h1 class="os-toc-title">Contents</h1>
+          <h1 class="os-toc-title">#{I18n.t(:toc_title)}</h1>
           <ol>
             #{li_tags}
           </ol>
@@ -43,7 +43,7 @@ module Kitchen
         <<~HTML
           <li class="os-toc-chapter" cnx-archive-shortid="" cnx-archive-uri="">
             <a href="##{chapter.title.id}">
-              <span class="os-number"><span class="os-part-text">Chapter </span>#{chapter.count_in(:book)}</span>
+              <span class="os-number"><span class="os-part-text">#{I18n.t(:chapter)} </span>#{chapter.count_in(:book)}</span>
               <span class="os-divider"> </span>
               <span class="os-text" data-type="" itemprop="">#{chapter.title.first!('.os-text').text}</span>
             </a>

--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -2,6 +2,9 @@ en:
   figure: Figure
   table_label: Table
   appendix: Appendix
+  chapter: Chapter
+  chapter_outline: Chapter Outline
+  toc_title: Contents
   example_label: Example
   exercise_label: Exercise
   stepwise_step_label: Step

--- a/spec/directions/bake_chapter_introductions_spec.rb
+++ b/spec/directions/bake_chapter_introductions_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 
 RSpec.describe Kitchen::Directions::BakeChapterIntroductions do
+  before do
+    stub_locales({
+      'chapter_outline': 'Chapter Outline'
+    })
+  end
+
   let(:book) do
     book_containing(html:
       <<~HTML

--- a/spec/directions/bake_chapter_title/v1_spec.rb
+++ b/spec/directions/bake_chapter_title/v1_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 RSpec.describe Kitchen::Directions::BakeChapterTitle::V1 do
+  before do
+    stub_locales({
+      'chapter': 'Chapter'
+    })
+  end
 
   let(:book1) do
     book_containing(html:

--- a/spec/directions/bake_toc_spec.rb
+++ b/spec/directions/bake_toc_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 
 RSpec.describe Kitchen::Directions::BakeToc do
+  before do
+    stub_locales({
+      'toc_title': 'Contents',
+      'chapter': 'Chapter'
+    })
+  end
 
   let(:book_1) do
     book_containing(html:


### PR DESCRIPTION
Replaces hardcoded terms in the bake with i18n references.

Adds to en.yml the terms:
chapter: Chapter
chapter_outline: Chapter Outline
toc_title: Contents