### PR TITLE
refactor bake exercise v1 to accept section exercise classes titles

### DIFF
--- a/lib/kitchen/directions/bake_exercises/main.rb
+++ b/lib/kitchen/directions/bake_exercises/main.rb
@@ -3,8 +3,12 @@
 module Kitchen
   module Directions
     module BakeExercises
-      def self.v1(book:)
-        V1.new.bake(book: book)
+      def self.v1(book:, exercise_section_classname:, exercise_section_title:)
+        V1.new.bake(
+          book: book,
+          exercise_section_classname: exercise_section_classname,
+          exercise_section_title: exercise_section_title
+        )
       end
     end
   end

--- a/lib/kitchen/directions/bake_exercises/v1.rb
+++ b/lib/kitchen/directions/bake_exercises/v1.rb
@@ -3,7 +3,11 @@
 module Kitchen::Directions::BakeExercises
   class V1
     renderable
-    def bake(book:)
+    def bake(
+      book:,
+      exercise_section_classname: 'exercises',
+      exercise_section_title: 'eoc_exercises_title'
+    )
       metadata_elements = book.metadata.children_to_keep.copy
 
       solutions_clipboards = []
@@ -14,7 +18,9 @@ module Kitchen::Directions::BakeExercises
         solutions_clipboards.push(solution_clipboard)
 
         chapter.non_introduction_pages.each do |page|
-          exercise_section = page.exercises
+          exercise_section = page.exercises(exercise_section_classname)
+          next if exercise_section.nil?
+
           exercise_section.titles.first&.trash
 
           bake_exercise_section_title(
@@ -36,12 +42,12 @@ module Kitchen::Directions::BakeExercises
 
         chapter.append(child:
           <<~HTML
-            <div class="os-eoc os-exercises-container" data-type="composite-page" data-uuid-key=".exercises">
+            <div class= "os-eoc os-#{exercise_section_classname}-container" data-type="composite-page" data-uuid-key=".#{exercise_section_classname}">
               <h2 data-type="document-title">
-                <span class="os-text">#{I18n.t(:eoc_exercises_title)}</span>
+                <span class="os-text">#{I18n.t(:"#{exercise_section_title}")}</span>
               </h2>
               <div data-type="metadata" style="display: none;">
-                <h1 data-type="document-title" itemprop="name">#{I18n.t(:eoc_exercises_title)}</h1>
+                <h1 data-type="document-title" itemprop="name">#{I18n.t(:"#{exercise_section_title}")}</h1>
                 #{metadata_elements.paste}
               </div>
               #{exercise_clipboard.paste}

--- a/lib/kitchen/page_element.rb
+++ b/lib/kitchen/page_element.rb
@@ -83,8 +83,8 @@ module Kitchen
     # @raise [ElementNotFoundError] if no matching element is found
     # @return [Element]
     #
-    def exercises
-      first!('section.exercises')
+    def exercises(exercise_section_classname)
+      first("section.#{exercise_section_classname}")
     end
 
     # Returns the key concepts

--- a/spec/directions/bake_exercises/main_spec.rb
+++ b/spec/directions/bake_exercises/main_spec.rb
@@ -5,7 +5,15 @@ require 'spec_helper'
 RSpec.describe Kitchen::Directions::BakeExercises do
   it 'calls v1' do
     expect_any_instance_of(Kitchen::Directions::BakeExercises::V1).to receive(:bake)
-      .with(book: 'blah')
-    described_class.v1(book: 'blah')
+      .with(
+        book: 'blah',
+        exercise_section_classname: 'classname',
+        exercise_section_title: 'title'
+    )
+    described_class.v1(
+      book: 'blah',
+      exercise_section_classname: 'classname',
+      exercise_section_title: 'title'
+    )
   end
 end


### PR DESCRIPTION
Refactors `bake_exercises v1` to accept exercises section classes (In sociology the exercises have only different section classes and titles) and Titles form `book/locales`. 
I'm not quite sure if this is the correct approach (I have seen Karina's created a separate `chapter_review_exercises`  bake file). Please let me know if this should be done rather similar to chapter review exercises (separate bake files bake `section-quiz` exercises and `short-answer` exercises).