### PR TITLE
Add option to decorator equation numbers with parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Adds a decorating option of equation numbers on `BakeEquations` (minor)
 
 ## [3.1.0] - 2021-04-19
 

--- a/lib/kitchen/directions/bake_equations.rb
+++ b/lib/kitchen/directions/bake_equations.rb
@@ -3,7 +3,7 @@
 module Kitchen
   module Directions
     module BakeEquations
-      def self.v1(book:)
+      def self.v1(book:, number_decorator: :none)
         book.chapters.search('[data-type="equation"]:not(.unnumbered)').each do |eq|
           chapter = eq.ancestor(:chapter)
           number = "#{chapter.count_in(:book)}.#{eq.count_in(:chapter)}"
@@ -12,11 +12,21 @@ module Kitchen
           equation_label = "#{I18n.t(:equation)} #{number}"
           book.document.pantry(name: :link_text).store equation_label, label: eq.id
 
+          decorated_number =
+            case number_decorator
+            when :none
+              number
+            when :parentheses
+              "(#{number})"
+            else
+              raise "Unsupported number_decorator '#{number_decorator}'"
+            end
+
           # Bake the equation
           eq.append(child:
             <<~HTML
               <div class="os-equation-number">
-                <span class="os-number">#{number}</span>
+                <span class="os-number">#{decorated_number}</span>
               </div>
             HTML
           )

--- a/spec/directions/bake_equations_spec.rb
+++ b/spec/directions/bake_equations_spec.rb
@@ -71,6 +71,28 @@ RSpec.describe Kitchen::Directions::BakeEquations do
     )
   end
 
+  it 'decorates number with parenthesis' do
+    described_class.v1(book: book_with_one_equation, number_decorator: :parentheses)
+    expect(book_with_one_equation.chapters.first).to match_normalized_html(
+      <<~HTML
+        <div data-type="chapter">
+          <div data-type="equation" id="123">
+            <p>equation 1</p>
+            <div class="os-equation-number">
+              <span class="os-number">(1.1)</span>
+            </div>
+          </div>
+        </div>
+      HTML
+    )
+  end
+
+  it 'raises if decorator is not supported' do
+    expect {
+      described_class.v1(book: book_with_one_equation, number_decorator: :dots)
+    }.to raise_error("Unsupported number_decorator 'dots'")
+  end
+
   it 'stores link text' do
     pantry = book_with_one_equation.document.pantry(name: :link_text)
     expect(pantry).to receive(:store).with('Equation 1.1', { label: '123' })


### PR DESCRIPTION
`BakeEquations.v1(book: book)` still adds equation numbers like `2.4`

This PR makes it so that 

`BakeEquations.v1(book: book, number_decorator: :parentheses)` adds equation numbers like `(2.4)`