### PR TITLE
Add terms from composite pages to index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add terms from composite pages to index (minor)
 * Access `.pantry` and `.clipboard` through an element instead of just its document (minor)
 
 ## [3.2.0] - 2021-04-19

--- a/lib/kitchen/composite_page_element.rb
+++ b/lib/kitchen/composite_page_element.rb
@@ -26,7 +26,7 @@ module Kitchen
       # Get the title in the immediate children, not the one in the metadata.  Could use
       # CSS of ":not([data-type='metadata']) > [data-type='document-title'], [data-type='document-title']"
       # but xpath is shorter
-      first!("./*[@data-type = 'document-title']")
+      first!("./*[@data-type = 'document-title' or @data-type = 'title']")
     end
 
     # Returns true if this class represents the element for the given node

--- a/lib/kitchen/directions/bake_index/v1.rb
+++ b/lib/kitchen/directions/bake_index/v1.rb
@@ -119,26 +119,38 @@ module Kitchen::Directions::BakeIndex
       @index = Index.new
 
       book.pages.terms.each do |term_element|
-        # Markup the term
         page = term_element.ancestor(:page)
         term_element.id = "auto_#{page.id}_term#{term_element.count_in(:book)}"
+        page_title = page.title.text
+        add_term_to_index(term_element, page_title)
+      end
 
-        group_by = term_element.text.strip[0]
-        group_by = I18n.t(:eob_index_symbols_group) unless group_by.match?(/\w/)
-        term_element['group-by'] = group_by
-
-        # Add it to our index object
-        @index.add_term(
-          Term.new(
-            text: term_element.text,
-            id: term_element.id,
-            group_by: group_by,
-            page_title: page.title.text.gsub(/\n/, '')
-          )
-        )
+      book.chapters.composite_pages.terms.each do |term_element|
+        page = term_element.ancestor(:composite_page)
+        chapter = term_element.ancestor(:chapter)
+        term_element.id = "auto_composite_page_term#{term_element.count_in(:book)}"
+        chapter_number = chapter.count_in(:book)
+        page_title = "#{chapter_number} #{page.title.text.strip}".strip
+        add_term_to_index(term_element, page_title)
       end
 
       book.first('body').append(child: render(file: 'v1.xhtml.erb'))
+    end
+
+    def add_term_to_index(term_element, page_title)
+      group_by = term_element.text.strip[0]
+      group_by = I18n.t(:eob_index_symbols_group) unless group_by.match?(/\w/)
+      term_element['group-by'] = group_by
+
+      # Add it to our index object
+      @index.add_term(
+        Term.new(
+          text: term_element.text,
+          id: term_element.id,
+          group_by: group_by,
+          page_title: page_title.gsub(/\n/, '')
+        )
+      )
     end
 
   end

--- a/spec/directions/bake_index/v1_spec.rb
+++ b/spec/directions/bake_index/v1_spec.rb
@@ -35,6 +35,20 @@ RSpec.describe Kitchen::Directions::BakeIndex::V1 do
             <span data-type="term">ΔE</span>
             <span data-type="term"><em>sp</em><sup>3</sup><em>d</em><sup>2</sup> orbitals</span>
           </div>
+          <div data-type="composite-chapter">
+            <div data-type="document-title">Chapter Review</div>
+            <div data-type="composite-page">
+              <div data-type="title">EOC Section Title</div>
+              <span data-type="term">composite page in a composite chapter</span>
+            </div>
+          </div>
+        </div>
+        <div data-type="chapter">
+          <div data-type="page" id="p4"/>
+          <div data-type="composite-page">
+            <div data-type="document-title">Another EOC Section</div>
+            <span data-type="term">composite page at the top level</span>
+          </div>
         </div>
       HTML
     )
@@ -63,6 +77,21 @@ RSpec.describe Kitchen::Directions::BakeIndex::V1 do
               <span class="os-term" group-by="Symbols">&#x394;E</span>
               <a class="os-term-section-link" href="#auto_p2_term4">
                 <span class="os-term-section">1.1 First Page</span>
+              </a>
+            </div>
+          </div>
+          <div class="group-by">
+            <span class="group-label">C</span>
+            <div class="os-index-item">
+              <span class="os-term" group-by="c">composite page at the top level</span>
+              <a class="os-term-section-link" href="#auto_composite_page_term2">
+                <span class="os-term-section">2 Another EOC Section</span>
+              </a>
+            </div>
+            <div class="os-index-item">
+              <span class="os-term" group-by="c">composite page in a composite chapter</span>
+              <a class="os-term-section-link" href="#auto_composite_page_term1">
+                <span class="os-term-section">1 EOC Section Title</span>
               </a>
             </div>
           </div>


### PR DESCRIPTION
Currently, easybake handles terms that appear in composite pages by acting as if they originated from the final page in the chapter. This feature:

1. ensures terms in composite pages are not overlooked in kitchen
2. updates the link text for the key term callback in the index to give the chapter number & eoc section name, instead of the final page of the chapter

![image](https://user-images.githubusercontent.com/26280712/116443815-b76db080-a819-11eb-8b21-b7b358e70fd8.png)
^ easybake version

![image](https://user-images.githubusercontent.com/26280712/116443836-bf2d5500-a819-11eb-9b55-168eb50d0c30.png)
^ kitchen version