### PR TITLE
Case sensitivity with index items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+* Update `BakeIndex` term capitalization handling to be less case sensitive (minor)
 * Added a title tag variable to choose between h2 and h3 for children of chapter review (minor)
 * Added a fix for examples not to bake table captions (minor)
 * Replaced a .text with .children to include math text (minor)

--- a/lib/kitchen/directions/bake_index/v1.rb
+++ b/lib/kitchen/directions/bake_index/v1.rb
@@ -44,6 +44,10 @@ module Kitchen::Directions::BakeIndex
         @term_text = @term_text.uncapitalize
       end
 
+      def capitalize_term_text!
+        @term_text = @term_text.capitalize
+      end
+
       def <=>(other)
         sortable <=> other.sortable
       end
@@ -83,6 +87,11 @@ module Kitchen::Directions::BakeIndex
         @items_by_term_text[term.text] ||= begin
           different_caps_item = @items_by_term_text[term.text.uncapitalize]
           different_caps_item&.uncapitalize_term_text!
+
+          unless different_caps_item
+            different_caps_item = @items_by_term_text[term.text.capitalize]
+            different_caps_item&.capitalize_term_text!
+          end
 
           (different_caps_item || IndexItem.new(term_text: term.text)).tap do |item|
             @items.add(item)

--- a/spec/directions/bake_index/v1_spec.rb
+++ b/spec/directions/bake_index/v1_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe Kitchen::Directions::BakeIndex::V1 do
           <div data-type="document-title">Preface</div>
           <span data-type="term">foo</span>
           <span data-type="term">Foo</span>
+          <span data-type="term">Bar</span>
+          <span data-type="term">bar</span>
         </div>
         <div data-type="chapter">
           <div data-type="page" id="p2">
@@ -75,8 +77,21 @@ RSpec.describe Kitchen::Directions::BakeIndex::V1 do
             <span class="group-label">Symbols</span>
             <div class="os-index-item">
               <span class="os-term" group-by="Symbols">&#x394;E</span>
-              <a class="os-term-section-link" href="#auto_p2_term4">
+              <a class="os-term-section-link" href="#auto_p2_term6">
                 <span class="os-term-section">1.1 First Page</span>
+              </a>
+            </div>
+          </div>
+          <div class="group-by">
+            <span class="group-label">B</span>
+            <div class="os-index-item">
+              <span class="os-term" group-by="B">Bar</span>
+              <a class="os-term-section-link" href="#auto_p1_term3">
+                <span class="os-term-section">Preface</span>
+              </a>
+              <span class="os-index-link-separator">, </span>
+              <a class="os-term-section-link" href="#auto_p1_term4">
+                <span class="os-term-section">Preface</span>
               </a>
             </div>
           </div>
@@ -107,7 +122,7 @@ RSpec.describe Kitchen::Directions::BakeIndex::V1 do
                 <span class="os-term-section">Preface</span>
               </a>
               <span class="os-index-link-separator">, </span>
-              <a class="os-term-section-link" href="#auto_p2_term3">
+              <a class="os-term-section-link" href="#auto_p2_term5">
                 <span class="os-term-section">1.1 First Page</span>
               </a>
             </div>
@@ -116,7 +131,7 @@ RSpec.describe Kitchen::Directions::BakeIndex::V1 do
             <span class="group-label">S</span>
             <div class="os-index-item">
               <span class="os-term" group-by="s">sp3d2 orbitals</span>
-              <a class="os-term-section-link" href="#auto_p2_term5">
+              <a class="os-term-section-link" href="#auto_p2_term7">
                 <span class="os-term-section">1.1 First Page</span>
               </a>
             </div>


### PR DESCRIPTION
Index items like "Newton" and "newton" should be considered the same (disregard case). This currently works if the first occurrence is lowercase and subsequent occurrences are capitalized, but not vice versa. This PR makes it go both ways.