### PR TITLE
rm toc xmlns 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Replaced a .text with .children to include math text (minor)
 * Changed title tag on numbered notes to always be h3 (major)
 * Storing all note subtitles in the pantry for link placeholders (minor)
+* Added another xmlns string option to remove if clone
 
 * Add `BakeFreeResponse` Directions (minor)
 * Add terms from composite pages to index (minor)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Replaced a .text with .children to include math text (minor)
 * Changed title tag on numbered notes to always be h3 (major)
 * Storing all note subtitles in the pantry for link placeholders (minor)
-* Added another xmlns string option to remove if clone
+* Added another xmlns string option to remove if clone (minor)
 
 * Add `BakeFreeResponse` Directions (minor)
 * Add terms from composite pages to index (minor)

--- a/lib/kitchen/element_base.rb
+++ b/lib/kitchen/element_base.rb
@@ -698,6 +698,7 @@ module Kitchen
     def remove_default_namespaces_if_clone(string)
       if is_a_clone
         string.gsub('xmlns:default="http://www.w3.org/1999/xhtml"', '').gsub('default:', '')
+        string.gsub('xmlns="http://www.w3.org/1999/xhtml"', '').gsub('default:', '')
       else
         string
       end


### PR DESCRIPTION
## Diff before change (click to enlarge)
![Screen Shot 2021-05-07 at 1 52 39 PM](https://user-images.githubusercontent.com/24909007/117495625-8426d200-af3b-11eb-8986-90f11f271e01.png)
## Diff after change
![Screen Shot 2021-05-07 at 1 54 06 PM](https://user-images.githubusercontent.com/24909007/117495797-ba645180-af3b-11eb-8fbd-5ad66c688d23.png)

I believe the namespace is being introduced on line `110` of `bake_toc.rb` when `page.title` is being copied because `page.title` returns the element without the namespace but `title = page.title.copy` returns the element with the namespace. 
Based on your comment on line`626` in `element_base.rb` I think this is expected BUT I think its also expected that the `paste` method should remove it becuse it uses `to_s` which calls `remove_default_namespaces_if_clone`. 
Thats when I realized that the `xmlns` in the TOC of Kendra and I's book is slightly different than the one in the method - which is why I added another gsub. 

Is there a way to condense this into one line? [I saw here that someone put different options in a hash? ](https://www.rubyguides.com/2019/07/ruby-gsub-method/)