### PR TITLE
Expand Eoc Specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Add `template` folder to kitchen to hold templates (minor)
 * Add `eoc_section_title_template` (minor)
+
 * Expand specs with `append_to` to have with/without `append_to` contexts (minor)
 
 ## [3.2.0] - 2021-04-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Add `template` folder to kitchen to hold templates (minor)
 * Add `eoc_section_title_template` (minor)
+* Expand specs with `append_to` to have with/without `append_to` contexts (minor)
 
 ## [3.2.0] - 2021-04-19
 

--- a/lib/kitchen/directions/bake_chapter_summary.rb
+++ b/lib/kitchen/directions/bake_chapter_summary.rb
@@ -5,18 +5,17 @@ module Kitchen
     # Bake directions for eoc summary
     #
     module BakeChapterSummary
-      def self.v1(chapter:, metadata_source:, append_to: nil, uuid_prefix: '.')
+      def self.v1(chapter:, metadata_source:, uuid_prefix: '.')
         V1.new.bake(
           chapter: chapter,
           metadata_source: metadata_source,
-          append_to: append_to,
           uuid_prefix: uuid_prefix
         )
       end
 
       class V1
         renderable
-        def bake(chapter:, metadata_source:, uuid_prefix:, append_to: nil)
+        def bake(chapter:, metadata_source:, uuid_prefix: '.')
           @metadata = metadata_source.children_to_keep.copy
           @klass = 'summary'
           @title = I18n.t(:eoc_summary_title)
@@ -50,7 +49,7 @@ module Kitchen
           return if summaries.none?
 
           @content = summaries.paste
-          append_to_element = append_to || chapter
+          append_to_element = chapter
           @in_composite_chapter = append_to_element[:'data-type'] == 'composite-chapter'
 
           append_to_element.append(child: render(file:

--- a/lib/kitchen/directions/bake_chapter_summary.rb
+++ b/lib/kitchen/directions/bake_chapter_summary.rb
@@ -49,10 +49,9 @@ module Kitchen
           return if summaries.none?
 
           @content = summaries.paste
-          append_to_element = chapter
-          @in_composite_chapter = append_to_element.is?(:composite_chapter)
+          @in_composite_chapter = false
 
-          append_to_element.append(child: render(file:
+          chapter.append(child: render(file:
             '../templates/eoc_section_title_template.xhtml.erb'))
         end
       end

--- a/lib/kitchen/directions/bake_further_research.rb
+++ b/lib/kitchen/directions/bake_further_research.rb
@@ -5,17 +5,16 @@ module Kitchen
     # Bake directions for further research
     #
     module BakeFurtherResearch
-      def self.v1(chapter:, metadata_source:, append_to: nil, uuid_prefix: '.')
+      def self.v1(chapter:, metadata_source:, uuid_prefix: '.')
         V1.new.bake(
           chapter: chapter,
           metadata_source: metadata_source,
-          append_to: append_to,
           uuid_prefix: uuid_prefix)
       end
 
       class V1
         renderable
-        def bake(chapter:, metadata_source:, append_to:, uuid_prefix:)
+        def bake(chapter:, metadata_source:, uuid_prefix: '.')
           @metadata = metadata_source.children_to_keep.copy
           @klass = 'further-research'
           @title = I18n.t(:eoc_further_research_title)
@@ -49,7 +48,7 @@ module Kitchen
 
           @content = further_researches.paste
 
-          append_to_element = append_to || chapter
+          append_to_element = chapter
           @in_composite_chapter = append_to_element[:'data-type'] == 'composite-chapter'
 
           append_to_element.append(child: render(file:

--- a/lib/kitchen/directions/bake_further_research.rb
+++ b/lib/kitchen/directions/bake_further_research.rb
@@ -48,10 +48,9 @@ module Kitchen
 
           @content = further_researches.paste
 
-          append_to_element = chapter
-          @in_composite_chapter = append_to_element.is?(:composite_chapter)
+          @in_composite_chapter = false
 
-          append_to_element.append(child: render(file:
+          chapter.append(child: render(file:
             '../templates/eoc_section_title_template.xhtml.erb'))
         end
       end

--- a/spec/directions/bake_chapter_glossary/v1_spec.rb
+++ b/spec/directions/bake_chapter_glossary/v1_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Kitchen::Directions::BakeChapterGlossary::V1 do
 
   before do
     stub_locales({
-      'eoc_key_terms_title': 'Key Terms'
+      'eoc_key_terms_title': 'Key Terms',
+      'eoc_exercises_title': 'Exercises'
     })
   end
 
@@ -33,34 +34,23 @@ RSpec.describe Kitchen::Directions::BakeChapterGlossary::V1 do
     )
   end
 
-  let(:chapter2) do
-    chapter_element(
+  let(:append_to) do
+    new_element(
       <<~HTML
-        <div data-type='chapter-review'>
-          <h1> wow </h1>
-        </div>
-        <div data-type='glossary'>
-          <div>
-            <dl>
-              <dt>ZzZ</dt>
-              <dd>Test 1</dd>
-            </dl>
-            <dl>
-              <dt>ZzZ</dt>
-              <dd>Achoo</dd>
-            </dl>
-            <dl>
-              <dt>ABD</dt>
-              <dd>Test 2</dd>
-            </dl>
+        <div class="os-eoc os-chapter-review-container" data-type="composite-chapter" data-uuid-key=".chapter-review">
+          <h2 data-type="document-title" id="composite-chapter-1">
+            <span class="os-text">foo</span>
+          </h2>
+          <div data-type="metadata" style="display: none;">
+            <h1 data-type="document-title" itemprop="name">foo</h1>
+            <div>metadata</div>
           </div>
         </div>
       HTML
     )
   end
 
-
-  context 'when append_to is null' do
+  context 'when append_to is nil' do
     it 'works' do
       metadata = metadata_element.append(child:
         <<~HTML
@@ -83,6 +73,47 @@ RSpec.describe Kitchen::Directions::BakeChapterGlossary::V1 do
                 <div class="print-style" id="print-style_copy_1">Print Style</div>
                 <div class="permissions" id="permissions_copy_1">Permissions</div>
                 <div data-type="subject" id="subject_copy_1">Subject</div>
+              </div>
+              <dl>
+                <dt>ABD</dt>
+                <dd>Test 2</dd>
+              </dl>
+              <dl>
+                <dt>ZzZ</dt>
+                <dd>Achoo</dd>
+              </dl>
+              <dl>
+                <dt>ZzZ</dt>
+                <dd>Test 1</dd>
+              </dl>
+            </div>
+          </div>
+        HTML
+      )
+    end
+  end
+
+  context 'when append_to is not nil' do
+    it 'works' do
+      expect(
+        described_class.new.bake(chapter: chapter, metadata_source: metadata_element, append_to: append_to)
+      ).to match_normalized_html(
+        <<~HTML
+          <div class="os-eoc os-chapter-review-container" data-uuid-key=".chapter-review" data-type="composite-chapter">
+            <h2 data-type="document-title" id="composite-chapter-1">
+              <span class="os-text">foo</span>
+            </h2>
+            <div data-type="metadata" style="display: none;">
+              <h1 data-type="document-title" itemprop="name">foo</h1>
+              <div>metadata</div>
+            </div>
+            <div class="os-eoc os-glossary-container" data-type="composite-page" data-uuid-key="glossary">
+              <h3 data-type="title">
+                <span class="os-text">Key Terms</span>
+              </h3>
+              <div data-type="metadata" style="display: none;">
+                <h1 data-type="document-title" itemprop="name">Exercises</h1>
+                <div class="authors" id="authors_copy_1">Authors</div><div class="publishers" id="publishers_copy_1">Publishers</div><div class="print-style" id="print-style_copy_1">Print Style</div><div class="permissions" id="permissions_copy_1">Permissions</div><div data-type="subject" id="subject_copy_1">Subject</div>
               </div>
               <dl>
                 <dt>ABD</dt>

--- a/spec/directions/bake_chapter_key_concepts_spec.rb
+++ b/spec/directions/bake_chapter_key_concepts_spec.rb
@@ -3,6 +3,13 @@
 require 'spec_helper'
 
 RSpec.describe Kitchen::Directions::BakeChapterKeyConcepts do
+  before do
+    stub_locales({
+      'eoc_key_concepts': 'Key Concepts',
+      'eoc_exercises_title': 'Exercises'
+    })
+  end
+
   let(:chapter) do
     chapter_element(
       <<~HTML
@@ -28,59 +35,132 @@ RSpec.describe Kitchen::Directions::BakeChapterKeyConcepts do
     )
   end
 
-  it 'works' do
-    expect(
-      described_class.v1(chapter: chapter, metadata_source: metadata_element)
-    ).to match_normalized_html(
+  let(:append_to) do
+    new_element(
       <<~HTML
-        <div data-type="chapter">
-          <div data-type="page">
-            <h1 data-type="document-title" id="page1TitleId">Page 1</h1>
-          </div>
-          <div data-type="page">
-            <h2 data-type="document-title" id="page2TitleId">
-              <span class="os-number">1.1</span>
-              <span class="os-divider"> </span>
-              <span data-type="" itemprop="" class="os-text">Baked Title</span>
-            </h2>
-          </div>
-          <div class="os-eoc os-key-concepts-container" data-type="composite-page" data-uuid-key=".key-concepts">
-            <h2 data-type="document-title">
-              <span class="os-text">Key Concepts</span>
-            </h2>
-            <div data-type="metadata" style="display: none;">
-              <h1 data-type="document-title" itemprop="name">Key Concepts</h1>
-              <div class="authors" id="authors_copy_1">Authors</div><div class="publishers" id="publishers_copy_1">Publishers</div><div class="print-style" id="print-style_copy_1">Print Style</div><div class="permissions" id="permissions_copy_1">Permissions</div><div data-type="subject" id="subject_copy_1">Subject</div>
-            </div>
-            <div class="os-key-concepts">
-              <div class="os-section-area">
-                <section id="sectionId1" class="key-concepts">
-                  <a href="#page1TitleId">
-                    <h3 data-type="document-title" id="page1TitleId_copy_1">
-                      <span class="os-number">1.1</span>
-                      <span class="os-divider"> </span>
-                      <span class="os-text" data-type="" itemprop="">Page 1</span>
-                    </h3>
-                  </a>
-                  <p>Concepts blah.</p>
-                </section>
-              </div>
-              <div class="os-section-area">
-                <section id="sectionId2" class="key-concepts">
-                  <a href="#page2TitleId">
-                    <h3 data-type="document-title" id="page2TitleId_copy_1">
-                      <span class="os-number">1.2</span>
-                      <span class="os-divider"> </span>
-                      <span class="os-text" data-type="" itemprop="">Baked Title</span>
-                    </h3>
-                  </a>
-                  <p>Concepts two</p>
-                </section>
-              </div>
-            </div>
+        <div class="os-eoc os-chapter-review-container" data-type="composite-chapter" data-uuid-key=".chapter-review">
+          <h2 data-type="document-title" id="composite-chapter-1">
+            <span class="os-text">foo</span>
+          </h2>
+          <div data-type="metadata" style="display: none;">
+            <h1 data-type="document-title" itemprop="name">foo</h1>
+            <div>metadata</div>
           </div>
         </div>
       HTML
     )
+  end
+
+  context 'when append_to is nil' do
+    it 'works' do
+      expect(
+        described_class.v1(chapter: chapter, metadata_source: metadata_element)
+      ).to match_normalized_html(
+        <<~HTML
+          <div data-type="chapter">
+            <div data-type="page">
+              <h1 data-type="document-title" id="page1TitleId">Page 1</h1>
+            </div>
+            <div data-type="page">
+              <h2 data-type="document-title" id="page2TitleId">
+                <span class="os-number">1.1</span>
+                <span class="os-divider"> </span>
+                <span data-type="" itemprop="" class="os-text">Baked Title</span>
+              </h2>
+            </div>
+            <div class="os-eoc os-key-concepts-container" data-type="composite-page" data-uuid-key=".key-concepts">
+              <h2 data-type="document-title">
+                <span class="os-text">Key Concepts</span>
+              </h2>
+              <div data-type="metadata" style="display: none;">
+                <h1 data-type="document-title" itemprop="name">Key Concepts</h1>
+                <div class="authors" id="authors_copy_1">Authors</div><div class="publishers" id="publishers_copy_1">Publishers</div><div class="print-style" id="print-style_copy_1">Print Style</div><div class="permissions" id="permissions_copy_1">Permissions</div><div data-type="subject" id="subject_copy_1">Subject</div>
+              </div>
+              <div class="os-key-concepts">
+                <div class="os-section-area">
+                  <section id="sectionId1" class="key-concepts">
+                    <a href="#page1TitleId">
+                      <h3 data-type="document-title" id="page1TitleId_copy_1">
+                        <span class="os-number">1.1</span>
+                        <span class="os-divider"> </span>
+                        <span class="os-text" data-type="" itemprop="">Page 1</span>
+                      </h3>
+                    </a>
+                    <p>Concepts blah.</p>
+                  </section>
+                </div>
+                <div class="os-section-area">
+                  <section id="sectionId2" class="key-concepts">
+                    <a href="#page2TitleId">
+                      <h3 data-type="document-title" id="page2TitleId_copy_1">
+                        <span class="os-number">1.2</span>
+                        <span class="os-divider"> </span>
+                        <span class="os-text" data-type="" itemprop="">Baked Title</span>
+                      </h3>
+                    </a>
+                    <p>Concepts two</p>
+                  </section>
+                </div>
+              </div>
+            </div>
+          </div>
+        HTML
+      )
+    end
+  end
+
+  context 'when append_to is not nil' do
+    it 'works' do
+      expect(
+        described_class.v1(chapter: chapter, metadata_source: metadata_element, append_to: append_to)
+      ).to match_normalized_html(
+        <<~HTML
+          <div class="os-eoc os-chapter-review-container" data-uuid-key=".chapter-review" data-type="composite-chapter">
+            <h2 data-type="document-title" id="composite-chapter-1">
+              <span class="os-text">foo</span>
+            </h2>
+            <div data-type="metadata" style="display: none;">
+              <h1 data-type="document-title" itemprop="name">foo</h1>
+              <div>metadata</div>
+            </div>
+            <div class="os-eoc os-key-concepts-container" data-type="composite-page" data-uuid-key=".key-concepts">
+              <h3 data-type="title">
+                <span class="os-text">Key Concepts</span>
+              </h3>
+              <div data-type="metadata" style="display: none;">
+                <h1 data-type="document-title" itemprop="name">Exercises</h1>
+                <div class="authors" id="authors_copy_1">Authors</div><div class="publishers" id="publishers_copy_1">Publishers</div><div class="print-style" id="print-style_copy_1">Print Style</div><div class="permissions" id="permissions_copy_1">Permissions</div><div data-type="subject" id="subject_copy_1">Subject</div>
+              </div>
+              <div class="os-key-concepts">
+                <div class="os-section-area">
+                  <section class="key-concepts" id="sectionId1">
+                    <a href="#page1TitleId">
+                      <h3 data-type="document-title" id="page1TitleId_copy_1">
+                        <span class="os-number">1.1</span>
+                        <span class="os-divider"> </span>
+                        <span class="os-text" data-type="" itemprop="">Page 1</span>
+                      </h3>
+                    </a>
+                    <p>Concepts blah.</p>
+                  </section>
+                </div>
+                <div class="os-section-area">
+                  <section class="key-concepts" id="sectionId2">
+                    <a href="#page2TitleId">
+                      <h3 data-type="document-title" id="page2TitleId_copy_1">
+                        <span class="os-number">1.2</span>
+                        <span class="os-divider"> </span>
+                        <span class="os-text" data-type="" itemprop="">Baked Title</span>
+                      </h3>
+                    </a>
+                    <p>Concepts two</p>
+                  </section>
+                </div>
+              </div>
+            </div>
+          </div>
+        HTML
+      )
+    end
   end
 end

--- a/spec/directions/bake_chapter_key_equations_spec.rb
+++ b/spec/directions/bake_chapter_key_equations_spec.rb
@@ -3,6 +3,14 @@
 require 'spec_helper'
 
 RSpec.describe Kitchen::Directions::BakeChapterKeyEquations do
+
+  before do
+    stub_locales({
+      'eoc_key_equations': 'Key Equations',
+      'eoc_exercises_title': 'Exercises'
+    })
+  end
+
   let(:chapter) do
     chapter_element(
       <<~HTML
@@ -14,26 +22,76 @@ RSpec.describe Kitchen::Directions::BakeChapterKeyEquations do
     )
   end
 
-  it 'works' do
-    expect(
-      described_class.v1(chapter: chapter, metadata_source: metadata_element)
-    ).to match_normalized_html(
+  let(:append_to) do
+    new_element(
       <<~HTML
-        <div data-type="chapter">
-          <div class="os-eoc os-key-equations-container" data-type="composite-page" data-uuid-key=".key-equations">
-            <h2 data-type="document-title">
-              <span class="os-text">Key Equations</span>
-            </h2>
-            <div data-type="metadata" style="display: none;">
-              <h1 data-type="document-title" itemprop="name">Key Equations</h1>
-              <div class="authors" id="authors_copy_1">Authors</div><div class="publishers" id="publishers_copy_1">Publishers</div><div class="print-style" id="print-style_copy_1">Print Style</div><div class="permissions" id="permissions_copy_1">Permissions</div><div data-type="subject" id="subject_copy_1">Subject</div>
-            </div>
-            <section class="key-equations">
-              <p>Equations blah.</p>
-            </section>
+        <div class="os-eoc os-chapter-review-container" data-type="composite-chapter" data-uuid-key=".chapter-review">
+          <h2 data-type="document-title" id="composite-chapter-1">
+            <span class="os-text">foo</span>
+          </h2>
+          <div data-type="metadata" style="display: none;">
+            <h1 data-type="document-title" itemprop="name">foo</h1>
+            <div>metadata</div>
           </div>
         </div>
       HTML
     )
+  end
+
+  context 'when append_to is nil' do
+    it 'works' do
+      expect(
+        described_class.v1(chapter: chapter, metadata_source: metadata_element)
+      ).to match_normalized_html(
+        <<~HTML
+          <div data-type="chapter">
+            <div class="os-eoc os-key-equations-container" data-type="composite-page" data-uuid-key=".key-equations">
+              <h2 data-type="document-title">
+                <span class="os-text">Key Equations</span>
+              </h2>
+              <div data-type="metadata" style="display: none;">
+                <h1 data-type="document-title" itemprop="name">Key Equations</h1>
+                <div class="authors" id="authors_copy_1">Authors</div><div class="publishers" id="publishers_copy_1">Publishers</div><div class="print-style" id="print-style_copy_1">Print Style</div><div class="permissions" id="permissions_copy_1">Permissions</div><div data-type="subject" id="subject_copy_1">Subject</div>
+              </div>
+              <section class="key-equations">
+                <p>Equations blah.</p>
+              </section>
+            </div>
+          </div>
+        HTML
+      )
+    end
+  end
+
+  context 'when append_to is not nil' do
+    it 'works' do
+      expect(
+        described_class.v1(chapter: chapter, metadata_source: metadata_element, append_to: append_to)
+      ).to match_normalized_html(
+        <<~HTML
+          <div class="os-eoc os-chapter-review-container" data-uuid-key=".chapter-review" data-type="composite-chapter">
+            <h2 data-type="document-title" id="composite-chapter-1">
+              <span class="os-text">foo</span>
+            </h2>
+            <div data-type="metadata" style="display: none;">
+              <h1 data-type="document-title" itemprop="name">foo</h1>
+              <div>metadata</div>
+            </div>
+            <div class="os-eoc os-key-equations-container" data-type="composite-page" data-uuid-key=".key-equations">
+              <h3 data-type="title">
+                <span class="os-text">Key Equations</span>
+              </h3>
+              <div data-type="metadata" style="display: none;">
+                <h1 data-type="document-title" itemprop="name">Exercises</h1>
+                <div class="authors" id="authors_copy_1">Authors</div><div class="publishers" id="publishers_copy_1">Publishers</div><div class="print-style" id="print-style_copy_1">Print Style</div><div class="permissions" id="permissions_copy_1">Permissions</div><div data-type="subject" id="subject_copy_1">Subject</div>
+              </div>
+              <section class="key-equations">
+                <p>Equations blah.</p>
+              </section>
+            </div>
+          </div>
+        HTML
+      )
+    end
   end
 end

--- a/spec/directions/bake_chapter_summary_spec.rb
+++ b/spec/directions/bake_chapter_summary_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Kitchen::Directions::BakeChapterSummary do
 
   before do
     stub_locales({
-      'eoc_summary_title': 'Summary'
+      'eoc_summary_title': 'Summary',
+      'eoc_exercises_title': 'Exercises'
     })
   end
 


### PR DESCRIPTION
Expand the specs of those using the template and append_to to have w/append_to specs and w/o

(and also remove an unnecessary append_to in two cases)