### PR TITLE
Move exercise pantry label storage to BakeNumberedExercises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* `BakeFootnotes` now looks for footnotes in composite chapters
+* Move exercise pantry label storage to `BakeNumberedExercises` to ensure consistency between exercise number and link text
 * Update `BakeIndex` term capitalization handling to be less case sensitive (minor)
 * Added a title tag variable to choose between h2 and h3 for children of chapter review (minor)
 * Added a fix for examples not to bake table captions (minor)

--- a/lib/kitchen/directions/bake_footnotes/v1.rb
+++ b/lib/kitchen/directions/bake_footnotes/v1.rb
@@ -8,7 +8,8 @@ module Kitchen::Directions::BakeFootnotes
       # appendices, etc) or within chapters. Tackle each case separately
 
       book.body.element_children.only(Kitchen::PageElement,
-                                      Kitchen::CompositePageElement).each do |page|
+                                      Kitchen::CompositePageElement,
+                                      Kitchen::CompositeChapterElement).each do |page|
         bake_footnotes_within(page)
       end
 

--- a/lib/kitchen/directions/bake_numbered_exercise/v1.rb
+++ b/lib/kitchen/directions/bake_numbered_exercise/v1.rb
@@ -6,6 +6,10 @@ module Kitchen::Directions::BakeNumberedExercise
       problem = exercise.problem
       solution = exercise.solution
 
+      exercise.pantry(name: :link_text).store(
+        "#{I18n.t(:exercise_label)} #{exercise.ancestor(:chapter).count_in(:book)}.#{number}",
+        label: exercise.id
+      )
       problem_number = "<span class='os-number'>#{number}</span>"
 
       if solution.present?

--- a/lib/kitchen/directions/move_exercises_to_eoc/v1.rb
+++ b/lib/kitchen/directions/move_exercises_to_eoc/v1.rb
@@ -18,13 +18,6 @@ module Kitchen::Directions::MoveExercisesToEOC
         sections.each do |exercise_section|
           exercise_section.first("[data-type='title']")&.trash
 
-          exercise_section.exercises.each do |exercise|
-            exercise.pantry(name: :link_text).store(
-              "#{I18n.t(:exercise_label)} #{chapter.count_in(:book)}.#{exercise.count_in(:chapter)}",
-              label: exercise.id
-            )
-          end
-
           exercise_section.cut(to: exercise_clipboard)
         end
       end

--- a/lib/kitchen/directions/move_exercises_to_eoc/v2.rb
+++ b/lib/kitchen/directions/move_exercises_to_eoc/v2.rb
@@ -22,12 +22,6 @@ module Kitchen::Directions::MoveExercisesToEOC
 
           # Get parent page title
           section_title = Kitchen::Directions::EocSectionTitleLinkSnippet.v1(page: page)
-          exercise_section.exercises.each do |exercise|
-            exercise.pantry(name: :link_text).store(
-              "#{I18n.t(:exercise_label)} #{chapter.count_in(:book)}.#{exercise.count_in(:chapter)}",
-              label: exercise.id
-            )
-          end
 
           # Configure section title & wrappers
           exercise_section.prepend(child: section_title)

--- a/spec/directions/bake_footnotes/v1_spec.rb
+++ b/spec/directions/bake_footnotes/v1_spec.rb
@@ -26,6 +26,16 @@ RSpec.describe Kitchen::Directions::BakeFootnotes::V1 do
             <p><a href="#aside5" role="doc-noteref">[footnote]</a> Blah.</p>
             <aside id="aside5" type="footnote">Footnote content 5</aside>
           </div>
+          <div data-type="composite-chapter">
+            <div data-type="composite-page">
+              <p><a href="#aside7" role="doc-noteref">[footnote]</a> Blah.</p>
+              <aside id="aside7" type="footnote">Footnote content 7</aside>
+            </div>
+            <div data-type="composite-page">
+              <p><a href="#aside8" role="doc-noteref">[footnote]</a> Blah.</p>
+              <aside id="aside8" type="footnote">Footnote content 8</aside>
+            </div>
+          </div>
         </div>
         <div data-type="page">
           <p><a href="#aside6" role="doc-noteref">[footnote]</a> Blah.</p>
@@ -58,6 +68,16 @@ RSpec.describe Kitchen::Directions::BakeFootnotes::V1 do
           <div data-type="composite-page">
             <p><a href="#aside5" role="doc-noteref">4</a> Blah.</p>
             <aside id="aside5" type="footnote"><div data-type="footnote-number">4</div>Footnote content 5</aside>
+          </div>
+          <div data-type="composite-chapter">
+            <div data-type="composite-page">
+              <p><a href="#aside7" role="doc-noteref">5</a> Blah.</p>
+              <aside id="aside7" type="footnote"><div data-type="footnote-number">5</div>Footnote content 7</aside>
+            </div>
+            <div data-type="composite-page">
+              <p><a href="#aside8" role="doc-noteref">6</a> Blah.</p>
+              <aside id="aside8" type="footnote"><div data-type="footnote-number">6</div>Footnote content 8</aside>
+            </div>
           </div>
         </div>
         <div data-type="page">

--- a/spec/directions/bake_numbered_exercise/v1_spec.rb
+++ b/spec/directions/bake_numbered_exercise/v1_spec.rb
@@ -4,18 +4,20 @@ require 'spec_helper'
 
 RSpec.describe Kitchen::Directions::BakeNumberedExercise::V1 do
   let(:exercise1) do
-    exercise_element(
-      <<~HTML
-        <div data-type="exercise" id="exercise_id">
-          <div data-type="problem" id="problem_id">
-            <p>example content</p>
+    book_containing(html:
+      one_chapter_with_one_page_containing(
+        <<~HTML
+          <div data-type="exercise" id="exercise_id">
+            <div data-type="problem" id="problem_id">
+              <p>example content</p>
+            </div>
+            <div data-type="solution" id="solution_id">
+              <p>Solution content</p>
+            </div>
           </div>
-          <div data-type="solution" id="solution_id">
-            <p>Solution content</p>
-          </div>
-        </div>
-      HTML
-    )
+        HTML
+      )
+    ).chapters.exercises.first
   end
 
   context 'when solutions are not suppressed' do


### PR DESCRIPTION
Changes introduced:
1. Move exercise pantry label storage to `BakeNumberedExercises` to ensure consistency between exercise number and link text
2. `BakeFootnotes` now looks for footnotes in composite chapters