### PR TITLE
eoc metadata title fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix xmlns string replacement done in PR #209 (minor)
 * Remove depreciated directions `BakeNotes` and `BakeExercises` (major)
 
+* Adds `eoc_composite_metadata_title` to en.yml and eoc template (major)
+
 * Add `template` folder to kitchen to hold templates (minor)
 * Add `eoc_section_title_template` (minor)
 

--- a/lib/kitchen/templates/eoc_section_title_template.xhtml.erb
+++ b/lib/kitchen/templates/eoc_section_title_template.xhtml.erb
@@ -3,7 +3,7 @@
     <span class="os-text"><%= @title %></span>
   </<%= @in_composite_chapter ? 'h3' : 'h2' %>>
   <div data-type="metadata" style="display: none;">
-    <h1 data-type="document-title" itemprop="name"><%= @in_composite_chapter ? I18n.t(:eoc_exercises_title) : @title %></h1>
+    <h1 data-type="document-title" itemprop="name"><%= @in_composite_chapter ? I18n.t(:eoc_composite_metadata_title) : @title %></h1>
     <%= @metadata.paste %>
   </div>
   <%= @content %>

--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -20,6 +20,7 @@ en:
   eoc_key_terms_title: Key Terms
   eoc_summary_title: Summary
   eoc_exercises_title: Exercises
+  eoc_composite_metadata_title: Chapter Review
   eoc_answer_key_title: Answer Key
   eoc_key_concepts: Key Concepts
   eoc_key_equations: Key Equations

--- a/spec/directions/bake_chapter_glossary/v1_spec.rb
+++ b/spec/directions/bake_chapter_glossary/v1_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Kitchen::Directions::BakeChapterGlossary::V1 do
   before do
     stub_locales({
       'eoc_key_terms_title': 'Key Terms',
-      'eoc_exercises_title': 'Exercises'
+      'eoc_composite_metadata_title': 'Chapter Review'
     })
   end
 
@@ -112,7 +112,7 @@ RSpec.describe Kitchen::Directions::BakeChapterGlossary::V1 do
                 <span class="os-text">Key Terms</span>
               </h3>
               <div data-type="metadata" style="display: none;">
-                <h1 data-type="document-title" itemprop="name">Exercises</h1>
+                <h1 data-type="document-title" itemprop="name">Chapter Review</h1>
                 <div class="authors" id="authors_copy_1">Authors</div><div class="publishers" id="publishers_copy_1">Publishers</div><div class="print-style" id="print-style_copy_1">Print Style</div><div class="permissions" id="permissions_copy_1">Permissions</div><div data-type="subject" id="subject_copy_1">Subject</div>
               </div>
               <dl>

--- a/spec/directions/bake_chapter_key_concepts_spec.rb
+++ b/spec/directions/bake_chapter_key_concepts_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Kitchen::Directions::BakeChapterKeyConcepts do
   before do
     stub_locales({
       'eoc_key_concepts': 'Key Concepts',
-      'eoc_exercises_title': 'Exercises'
+      'eoc_composite_metadata_title': 'Chapter Review'
     })
   end
 
@@ -128,7 +128,7 @@ RSpec.describe Kitchen::Directions::BakeChapterKeyConcepts do
                 <span class="os-text">Key Concepts</span>
               </h3>
               <div data-type="metadata" style="display: none;">
-                <h1 data-type="document-title" itemprop="name">Exercises</h1>
+                <h1 data-type="document-title" itemprop="name">Chapter Review</h1>
                 <div class="authors" id="authors_copy_1">Authors</div><div class="publishers" id="publishers_copy_1">Publishers</div><div class="print-style" id="print-style_copy_1">Print Style</div><div class="permissions" id="permissions_copy_1">Permissions</div><div data-type="subject" id="subject_copy_1">Subject</div>
               </div>
               <div class="os-key-concepts">

--- a/spec/directions/bake_chapter_key_equations_spec.rb
+++ b/spec/directions/bake_chapter_key_equations_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Kitchen::Directions::BakeChapterKeyEquations do
   before do
     stub_locales({
       'eoc_key_equations': 'Key Equations',
-      'eoc_exercises_title': 'Exercises'
+      'eoc_composite_metadata_title': 'Chapter Review'
     })
   end
 
@@ -82,7 +82,7 @@ RSpec.describe Kitchen::Directions::BakeChapterKeyEquations do
                 <span class="os-text">Key Equations</span>
               </h3>
               <div data-type="metadata" style="display: none;">
-                <h1 data-type="document-title" itemprop="name">Exercises</h1>
+                <h1 data-type="document-title" itemprop="name">Chapter Review</h1>
                 <div class="authors" id="authors_copy_1">Authors</div><div class="publishers" id="publishers_copy_1">Publishers</div><div class="print-style" id="print-style_copy_1">Print Style</div><div class="permissions" id="permissions_copy_1">Permissions</div><div data-type="subject" id="subject_copy_1">Subject</div>
               </div>
               <section class="key-equations">

--- a/spec/directions/move_exercises_to_eoc/v1_spec.rb
+++ b/spec/directions/move_exercises_to_eoc/v1_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe Kitchen::Directions::MoveExercisesToEOC::V1 do
   before do
     stub_locales({
-      'eoc_exercises_title': 'Review Exercises',
+      'eoc_composite_metadata_title': 'Exercises',
       'eoc_chapter_review': 'Chapter Review',
       'eoc': {
         'review-exercises': 'foo'
@@ -69,7 +69,7 @@ RSpec.describe Kitchen::Directions::MoveExercisesToEOC::V1 do
                     <span class="os-text">foo</span>
                   </h3>
                   <div data-type="metadata" style="display: none;">
-                    <h1 data-type="document-title" itemprop="name">Review Exercises</h1>
+                    <h1 data-type="document-title" itemprop="name">Exercises</h1>
                     <div class="authors" id="authors_copy_1">Authors</div>
                     <div class="publishers" id="publishers_copy_1">Publishers</div>
                     <div class="print-style" id="print-style_copy_1">Print Style</div>

--- a/spec/directions/move_exercises_to_eoc/v2_spec.rb
+++ b/spec/directions/move_exercises_to_eoc/v2_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe Kitchen::Directions::MoveExercisesToEOC::V2 do
   before do
     stub_locales({
-      'eoc_exercises_title': 'Review Exercises',
+      'eoc_composite_metadata_title': 'Review Exercises',
       'eoc_chapter_review': 'Chapter Review',
       'eoc': {
         'CLASSNAME': 'foo'


### PR DESCRIPTION
Adds eoc_composite_metadata_title to localization and the eoc template to more accurately reflect easybake (default is 'Chapter Review')