### PR TITLE
support non-root element namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Support namespaces defined on elements other than the root (minor)
 * `BakeFootnotes` now looks for footnotes in composite chapters
 * Move exercise pantry label storage to `BakeNumberedExercises` to ensure consistency between exercise number and link text
 * Update `BakeIndex` term capitalization handling to be less case sensitive (minor)

--- a/lib/kitchen/config.rb
+++ b/lib/kitchen/config.rb
@@ -11,6 +11,12 @@ module Kitchen
     #
     attr_reader :selectors
 
+    # @!attribute [rw] enable_all_namespaces
+    #
+    # @return [Boolean]
+    #
+    attr_accessor :enable_all_namespaces
+
     # Creates a new config from a file (not implemented)
     #
     def self.new_from_file(_file)
@@ -21,6 +27,7 @@ module Kitchen
     #
     def initialize(hash: {}, selectors: nil)
       @selectors = selectors || Kitchen::Selectors::Standard1.new
+      @enable_all_namespaces = hash[:enable_all_namespaces] || true
       @hash = hash
     end
   end

--- a/lib/kitchen/document.rb
+++ b/lib/kitchen/document.rb
@@ -46,6 +46,17 @@ module Kitchen
       @config = config || Config.new
       @next_paste_count_for_id = {}
       @id_copy_suffix = '_copy_'
+
+      # Nokogiri by default only recognizes the namespaces on the root node.  Collect all
+      # namespaces and add them manually.
+      return unless @config.enable_all_namespaces && raw.present?
+
+      raw.collect_namespaces.each do |namespace, url|
+        prefix, name = namespace.split(':')
+        next unless prefix == 'xmlns' && name.present?
+
+        raw.root.add_namespace_definition(name, url)
+      end
     end
 
     # Returns an enumerator that iterates over all children of this document

--- a/spec/namespace_spec.rb
+++ b/spec/namespace_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'namespace operations' do
+  let(:book) do
+    book_containing(html:
+      one_chapter_with_one_page_containing(
+        <<~HTML
+          <span xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0"
+                xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0"
+                data-type="term"
+                cmlnle:reference="Wundt, Wilhelm (1832-1920)"
+                cxlxt:index="name"
+                cxlxt:name="Wundta, Wilhelma">Wilhelma Wundta</span>
+            <span xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0"
+                xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0"
+                cxlxt:index="foo">Other span</span>
+        HTML
+    ))
+  end
+
+  it 'can select elements by namespaced attributes' do
+    expect(book.chapters.first.search("[cxlxt|index='name']").first.text).to eq 'Wilhelma Wundta'
+  end
+end


### PR DESCRIPTION
Nokogiri, the library used by Kitchen, by default only parses namespaces defined on the root element.  There are cases where namespaces are defined on child elements of the document, e.g. on terms in Polish books.  This PR finds those subelement namespaces and explicitly adds them to the root node so that searches can be run that are aware of those namespaces.