### PR TITLE
Enumerator selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Changes `default_css_or_xpath` to optionally be a proc to be evaluated w.r.t. a document's config (minor)
 * `BakeFootnotes` now looks for footnotes in composite chapters
 * Move exercise pantry label storage to `BakeNumberedExercises` to ensure consistency between exercise number and link text
 * Update `BakeIndex` term capitalization handling to be less case sensitive (minor)

--- a/lib/kitchen/book_element.rb
+++ b/lib/kitchen/book_element.rb
@@ -47,5 +47,13 @@ module Kitchen
       first!('nav#toc')
     end
 
+    # Returns true if this class represents the element for the given node
+    #
+    # @param node [Nokogiri::XML::Node] the underlying node
+    # @return [Boolean]
+    #
+    def self.is_the_element_class_for?(node, **)
+      node.name == 'body'
+    end
   end
 end

--- a/lib/kitchen/chapter_element.rb
+++ b/lib/kitchen/chapter_element.rb
@@ -68,14 +68,5 @@ module Kitchen
       search('[data-type="abstract"]')
     end
 
-    # Returns true if this class represents the element for the given node
-    #
-    # @param node [Nokogiri::XML::Node] the underlying node
-    # @return [Boolean]
-    #
-    def self.is_the_element_class_for?(node, config:)
-      Selector.named(:chapter).matches?(node, config: config)
-    end
-
   end
 end

--- a/lib/kitchen/chapter_element.rb
+++ b/lib/kitchen/chapter_element.rb
@@ -73,8 +73,8 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node, **)
-      node['data-type'] == 'chapter'
+    def self.is_the_element_class_for?(node, config:)
+      Selector.named(:chapter).matches?(node, config: config)
     end
 
   end

--- a/lib/kitchen/chapter_element.rb
+++ b/lib/kitchen/chapter_element.rb
@@ -73,7 +73,7 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node)
+    def self.is_the_element_class_for?(node, **)
       node['data-type'] == 'chapter'
     end
 

--- a/lib/kitchen/chapter_element_enumerator.rb
+++ b/lib/kitchen/chapter_element_enumerator.rb
@@ -11,7 +11,7 @@ module Kitchen
     #
     def self.factory
       ElementEnumeratorFactory.new(
-        default_css_or_xpath: "div[data-type='chapter']", # TODO: element.document.selectors.chapter
+        default_css_or_xpath: Selector.named(:chapter),
         sub_element_class: ChapterElement,
         enumerator_class: self
       )

--- a/lib/kitchen/composite_chapter_element.rb
+++ b/lib/kitchen/composite_chapter_element.rb
@@ -39,7 +39,7 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node)
+    def self.is_the_element_class_for?(node, **)
       node['data-type'] == 'composite-chapter'
     end
 

--- a/lib/kitchen/composite_chapter_element.rb
+++ b/lib/kitchen/composite_chapter_element.rb
@@ -34,14 +34,5 @@ module Kitchen
       first!("./*[@data-type = 'document-title']")
     end
 
-    # Returns true if this class represents the element for the given node
-    #
-    # @param node [Nokogiri::XML::Node] the underlying node
-    # @return [Boolean]
-    #
-    def self.is_the_element_class_for?(node, config:)
-      Selector.named(:composite_chapter).matches?(node, config: config)
-    end
-
   end
 end

--- a/lib/kitchen/composite_chapter_element.rb
+++ b/lib/kitchen/composite_chapter_element.rb
@@ -39,8 +39,8 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node, **)
-      node['data-type'] == 'composite-chapter'
+    def self.is_the_element_class_for?(node, config:)
+      Selector.named(:composite_chapter).matches?(node, config: config)
     end
 
   end

--- a/lib/kitchen/composite_page_element.rb
+++ b/lib/kitchen/composite_page_element.rb
@@ -40,8 +40,8 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node, **)
-      node['data-type'] == 'composite-page'
+    def self.is_the_element_class_for?(node, config:)
+      Selector.named(:composite_page).matches?(node, config: config)
     end
 
     # Returns true if this page is a book index

--- a/lib/kitchen/composite_page_element.rb
+++ b/lib/kitchen/composite_page_element.rb
@@ -40,7 +40,7 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node)
+    def self.is_the_element_class_for?(node, **)
       node['data-type'] == 'composite-page'
     end
 

--- a/lib/kitchen/composite_page_element.rb
+++ b/lib/kitchen/composite_page_element.rb
@@ -35,15 +35,6 @@ module Kitchen
       first!("./*[@data-type = 'document-title' or @data-type = 'title']")
     end
 
-    # Returns true if this class represents the element for the given node
-    #
-    # @param node [Nokogiri::XML::Node] the underlying node
-    # @return [Boolean]
-    #
-    def self.is_the_element_class_for?(node, config:)
-      Selector.named(:composite_page).matches?(node, config: config)
-    end
-
     # Returns true if this page is a book index
     #
     # @return [Boolean]

--- a/lib/kitchen/composite_page_element_enumerator.rb
+++ b/lib/kitchen/composite_page_element_enumerator.rb
@@ -11,7 +11,7 @@ module Kitchen
     #
     def self.factory
       ElementEnumeratorFactory.new(
-        default_css_or_xpath: "div[data-type='composite-page']",
+        default_css_or_xpath: Selector.named(:composite_page),
         sub_element_class: CompositePageElement,
         enumerator_class: self
       )

--- a/lib/kitchen/element.rb
+++ b/lib/kitchen/element.rb
@@ -22,5 +22,15 @@ module Kitchen
     # # @!method pages
     # #   Returns a pages enumerator
     # def_delegators :as_enumerator, :pages, :chapters, :terms, :figures, :notes, :tables, :examples
+
+    # Returns true if this class represents the element for the given node; always false
+    # for this generic class
+    #
+    # @param node [Nokogiri::XML::Node] the underlying node
+    # @return [Boolean]
+    #
+    def self.is_the_element_class_for?(_node, **)
+      false
+    end
   end
 end

--- a/lib/kitchen/element.rb
+++ b/lib/kitchen/element.rb
@@ -19,10 +19,6 @@ module Kitchen
             short_type: short_type)
     end
 
-    # # @!method pages
-    # #   Returns a pages enumerator
-    # def_delegators :as_enumerator, :pages, :chapters, :terms, :figures, :notes, :tables, :examples
-
     # Returns true if this class represents the element for the given node; always false
     # for this generic class
     #

--- a/lib/kitchen/element_base.rb
+++ b/lib/kitchen/element_base.rb
@@ -167,7 +167,7 @@ module Kitchen
     # @return [Boolean]
     #
     def is?(type)
-      ElementBase.descendant!(type).is_the_element_class_for?(raw)
+      ElementBase.descendant!(type).is_the_element_class_for?(raw, config: config)
     end
 
     # Returns true if this class represents the element for the given node
@@ -175,7 +175,7 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(_node)
+    def self.is_the_element_class_for?(_node, **)
       # override this in subclasses
       false
     end

--- a/lib/kitchen/element_base.rb
+++ b/lib/kitchen/element_base.rb
@@ -173,11 +173,11 @@ module Kitchen
     # Returns true if this class represents the element for the given node
     #
     # @param node [Nokogiri::XML::Node] the underlying node
+    # @param config [Kitchen::Config]
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(_node, **)
-      # override this in subclasses
-      false
+    def self.is_the_element_class_for?(node, config:)
+      Selector.named(short_type).matches?(node, config: config)
     end
 
     # Returns true if this element has the given class

--- a/lib/kitchen/element_enumerator_factory.rb
+++ b/lib/kitchen/element_enumerator_factory.rb
@@ -12,8 +12,11 @@ module Kitchen
 
     # Creates a new instance
     #
-    # @param default_css_or_xpath [String] The selectors to substitute for the "$" character
-    #   when this factory is used to build an enumerator.
+    # @param default_css_or_xpath [String, Proc, Symbol] The selectors to substitute for the "$" character
+    #   when this factory is used to build an enumerator.  A string argument is used literally.  A proc
+    #   is eventually called given the document's Config object (for accessing selectors).  A symbol
+    #   is interpreted as the name of a selector and is called on the document's Config object's
+    #   selectors object.  The easiest way to get a Proc is to pass `Selector.named(:name_of_selector)`
     # @param sub_element_class [ElementBase] The element class to use for what the enumerator finds.
     # @param enumerator_class [ElementEnumeratorBase] The enumerator class to return
     # @param detect_sub_element_class [Boolean] If true, infers the sub_element_class from the node

--- a/lib/kitchen/element_enumerator_factory.rb
+++ b/lib/kitchen/element_enumerator_factory.rb
@@ -37,8 +37,6 @@ module Kitchen
     #   given to the factory in its constructor.
     #
     def build_within(enumerator_or_element, search_query: SearchQuery.new)
-      search_query.apply_default_css_or_xpath_and_normalize(default_css_or_xpath)
-
       case enumerator_or_element
       when ElementBase
         build_within_element(enumerator_or_element, search_query: search_query)
@@ -55,7 +53,7 @@ module Kitchen
     #
     def or_with(other_factory)
       self.class.new(
-        default_css_or_xpath: "#{default_css_or_xpath}, #{other_factory.default_css_or_xpath}",
+        default_css_or_xpath: [default_css_or_xpath, other_factory.default_css_or_xpath],
         enumerator_class: TypeCastingElementEnumerator,
         detect_sub_element_class: true
       )
@@ -64,6 +62,9 @@ module Kitchen
     protected
 
     def build_within_element(element, search_query:)
+      search_query.apply_default_css_or_xpath_and_normalize(default_css_or_xpath,
+                                                            config: element.config)
+
       enumerator_class.new(search_query: search_query) do |block|
         grand_ancestors = element.ancestors
         parent_ancestor = Ancestor.new(element)

--- a/lib/kitchen/element_factory.rb
+++ b/lib/kitchen/element_factory.rb
@@ -25,7 +25,7 @@ module Kitchen
                              element_class: nil,
                              default_short_type: nil,
                              detect_element_class: false)
-      element_class ||= detect_element_class ? specific_element_class_for_node(node) : Element
+      element_class ||= detect_element_class ? find_element_class(node, document.config) : Element
 
       if element_class == Element
         element_class.new(node: node,
@@ -37,9 +37,9 @@ module Kitchen
       end
     end
 
-    def self.specific_element_class_for_node(node)
+    def self.find_element_class(node, config)
       ELEMENT_CLASSES.find do |klass|
-        klass.is_the_element_class_for?(node)
+        klass.is_the_element_class_for?(node, config: config)
       end || Element
     end
 

--- a/lib/kitchen/example_element.rb
+++ b/lib/kitchen/example_element.rb
@@ -36,7 +36,7 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node)
+    def self.is_the_element_class_for?(node, **)
       node['data-type'] == 'example'
     end
 

--- a/lib/kitchen/example_element.rb
+++ b/lib/kitchen/example_element.rb
@@ -31,14 +31,5 @@ module Kitchen
       search("span[data-type='title']")
     end
 
-    # Returns true if this class represents the element for the given node
-    #
-    # @param node [Nokogiri::XML::Node] the underlying node
-    # @return [Boolean]
-    #
-    def self.is_the_element_class_for?(node, config:)
-      Selector.named(:example).matches?(node, config: config)
-    end
-
   end
 end

--- a/lib/kitchen/example_element.rb
+++ b/lib/kitchen/example_element.rb
@@ -36,8 +36,8 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node, **)
-      node['data-type'] == 'example'
+    def self.is_the_element_class_for?(node, config:)
+      Selector.named(:example).matches?(node, config: config)
     end
 
   end

--- a/lib/kitchen/example_element_enumerator.rb
+++ b/lib/kitchen/example_element_enumerator.rb
@@ -11,7 +11,7 @@ module Kitchen
     #
     def self.factory
       ElementEnumeratorFactory.new(
-        default_css_or_xpath: "div[data-type='example']", # TODO: element.document.selectors.example
+        default_css_or_xpath: Selector.named(:example),
         sub_element_class: ExampleElement,
         enumerator_class: self
       )

--- a/lib/kitchen/exercise_element.rb
+++ b/lib/kitchen/exercise_element.rb
@@ -28,7 +28,7 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node)
+    def self.is_the_element_class_for?(node, **)
       node['data-type'] == 'exercise'
     end
 

--- a/lib/kitchen/exercise_element.rb
+++ b/lib/kitchen/exercise_element.rb
@@ -28,8 +28,8 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node, **)
-      node['data-type'] == 'exercise'
+    def self.is_the_element_class_for?(node, config:)
+      Selector.named(:exercise).matches?(node, config: config)
     end
 
     # Returns the enumerator for problem.

--- a/lib/kitchen/exercise_element.rb
+++ b/lib/kitchen/exercise_element.rb
@@ -23,15 +23,6 @@ module Kitchen
       :exercise
     end
 
-    # Returns true if this class represents the element for the given node
-    #
-    # @param node [Nokogiri::XML::Node] the underlying node
-    # @return [Boolean]
-    #
-    def self.is_the_element_class_for?(node, config:)
-      Selector.named(:exercise).matches?(node, config: config)
-    end
-
     # Returns the enumerator for problem.
     #
     # @return ElementEnumerator

--- a/lib/kitchen/exercise_element_enumerator.rb
+++ b/lib/kitchen/exercise_element_enumerator.rb
@@ -11,7 +11,7 @@ module Kitchen
     #
     def self.factory
       ElementEnumeratorFactory.new(
-        default_css_or_xpath: "div[data-type='exercise']", # TODO: element.document.selectors.exercise
+        default_css_or_xpath: Selector.named(:exercise),
         sub_element_class: ExerciseElement,
         enumerator_class: self
       )

--- a/lib/kitchen/figure_element.rb
+++ b/lib/kitchen/figure_element.rb
@@ -52,8 +52,8 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node, **)
-      node.name == 'figure'
+    def self.is_the_element_class_for?(node, config:)
+      Selector.named(:figure).matches?(node, config: config)
     end
 
   end

--- a/lib/kitchen/figure_element.rb
+++ b/lib/kitchen/figure_element.rb
@@ -47,14 +47,5 @@ module Kitchen
       parent.name == 'figure'
     end
 
-    # Returns true if this class represents the element for the given node
-    #
-    # @param node [Nokogiri::XML::Node] the underlying node
-    # @return [Boolean]
-    #
-    def self.is_the_element_class_for?(node, config:)
-      Selector.named(:figure).matches?(node, config: config)
-    end
-
   end
 end

--- a/lib/kitchen/figure_element.rb
+++ b/lib/kitchen/figure_element.rb
@@ -52,7 +52,7 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node)
+    def self.is_the_element_class_for?(node, **)
       node.name == 'figure'
     end
 

--- a/lib/kitchen/figure_element_enumerator.rb
+++ b/lib/kitchen/figure_element_enumerator.rb
@@ -11,7 +11,7 @@ module Kitchen
     #
     def self.factory
       ElementEnumeratorFactory.new(
-        default_css_or_xpath: 'figure', # TODO: get from config?
+        default_css_or_xpath: Selector.named(:figure),
         sub_element_class: FigureElement,
         enumerator_class: self
       )

--- a/lib/kitchen/metadata_element.rb
+++ b/lib/kitchen/metadata_element.rb
@@ -30,14 +30,5 @@ module Kitchen
       search(%w([data-type='revised'] .authors .publishers .print-style .permissions
                 [data-type='subject']))
     end
-
-    # Returns true if this class represents the element for the given node
-    #
-    # @param node [Nokogiri::XML::Node] the underlying node
-    # @return [Boolean]
-    #
-    def self.is_the_element_class_for?(node, config:)
-      Selector.named(:metadata).matches?(node, config: config)
-    end
   end
 end

--- a/lib/kitchen/metadata_element.rb
+++ b/lib/kitchen/metadata_element.rb
@@ -30,5 +30,14 @@ module Kitchen
       search(%w([data-type='revised'] .authors .publishers .print-style .permissions
                 [data-type='subject']))
     end
+
+    # Returns true if this class represents the element for the given node
+    #
+    # @param node [Nokogiri::XML::Node] the underlying node
+    # @return [Boolean]
+    #
+    def self.is_the_element_class_for?(node, config:)
+      Selector.named(:metadata).matches?(node, config: config)
+    end
   end
 end

--- a/lib/kitchen/metadata_element_enumerator.rb
+++ b/lib/kitchen/metadata_element_enumerator.rb
@@ -11,7 +11,7 @@ module Kitchen
     #
     def self.factory
       ElementEnumeratorFactory.new(
-        default_css_or_xpath: "div[data-type='metadata']",
+        default_css_or_xpath: Selector.named(:metadata),
         sub_element_class: MetadataElement,
         enumerator_class: self
       )

--- a/lib/kitchen/note_element.rb
+++ b/lib/kitchen/note_element.rb
@@ -52,15 +52,6 @@ module Kitchen
       end
     end
 
-    # Returns true if this class represents the element for the given node
-    #
-    # @param node [Nokogiri::XML::Node] the underlying node
-    # @return [Boolean]
-    #
-    def self.is_the_element_class_for?(node, config:)
-      Selector.named(:note).matches?(node, config: config)
-    end
-
     protected
 
     def detected_note_title_key

--- a/lib/kitchen/note_element.rb
+++ b/lib/kitchen/note_element.rb
@@ -57,7 +57,7 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node)
+    def self.is_the_element_class_for?(node, **)
       node['data-type'] == 'note'
     end
 

--- a/lib/kitchen/note_element.rb
+++ b/lib/kitchen/note_element.rb
@@ -57,8 +57,8 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node, **)
-      node['data-type'] == 'note'
+    def self.is_the_element_class_for?(node, config:)
+      Selector.named(:note).matches?(node, config: config)
     end
 
     protected

--- a/lib/kitchen/note_element_enumerator.rb
+++ b/lib/kitchen/note_element_enumerator.rb
@@ -11,7 +11,7 @@ module Kitchen
     #
     def self.factory
       ElementEnumeratorFactory.new(
-        default_css_or_xpath: Selector.named(:note), # TODO: get from config?
+        default_css_or_xpath: Selector.named(:note),
         sub_element_class: NoteElement,
         enumerator_class: self
       )

--- a/lib/kitchen/note_element_enumerator.rb
+++ b/lib/kitchen/note_element_enumerator.rb
@@ -11,7 +11,7 @@ module Kitchen
     #
     def self.factory
       ElementEnumeratorFactory.new(
-        default_css_or_xpath: "div[data-type='note']", # TODO: get from config?
+        default_css_or_xpath: Selector.named(:note), # TODO: get from config?
         sub_element_class: NoteElement,
         enumerator_class: self
       )

--- a/lib/kitchen/page_element.rb
+++ b/lib/kitchen/page_element.rb
@@ -122,8 +122,8 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node, **)
-      node['data-type'] == 'page'
+    def self.is_the_element_class_for?(node, config:)
+      Selector.named(:page).matches?(node, config: config)
     end
 
   end

--- a/lib/kitchen/page_element.rb
+++ b/lib/kitchen/page_element.rb
@@ -117,14 +117,5 @@ module Kitchen
       search('section.free-response')
     end
 
-    # Returns true if this class represents the element for the given node
-    #
-    # @param node [Nokogiri::XML::Node] the underlying node
-    # @return [Boolean]
-    #
-    def self.is_the_element_class_for?(node, config:)
-      Selector.named(:page).matches?(node, config: config)
-    end
-
   end
 end

--- a/lib/kitchen/page_element.rb
+++ b/lib/kitchen/page_element.rb
@@ -122,7 +122,7 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node)
+    def self.is_the_element_class_for?(node, **)
       node['data-type'] == 'page'
     end
 

--- a/lib/kitchen/page_element_enumerator.rb
+++ b/lib/kitchen/page_element_enumerator.rb
@@ -11,7 +11,7 @@ module Kitchen
     #
     def self.factory
       ElementEnumeratorFactory.new(
-        default_css_or_xpath: "div[data-type='page']", # TODO: get from config?
+        default_css_or_xpath: Selector.named(:page),
         sub_element_class: PageElement,
         enumerator_class: self
       )

--- a/lib/kitchen/page_element_enumerator.rb
+++ b/lib/kitchen/page_element_enumerator.rb
@@ -11,7 +11,7 @@ module Kitchen
     #
     def self.factory
       ElementEnumeratorFactory.new(
-        default_css_or_xpath: "div[data-type='page']", # TODO: get from config?
+        default_css_or_xpath: ->(_) { "div[data-type='page']" }, # TODO: get from config?
         sub_element_class: PageElement,
         enumerator_class: self
       )

--- a/lib/kitchen/page_element_enumerator.rb
+++ b/lib/kitchen/page_element_enumerator.rb
@@ -11,7 +11,7 @@ module Kitchen
     #
     def self.factory
       ElementEnumeratorFactory.new(
-        default_css_or_xpath: ->(_) { "div[data-type='page']" }, # TODO: get from config?
+        default_css_or_xpath: "div[data-type='page']", # TODO: get from config?
         sub_element_class: PageElement,
         enumerator_class: self
       )

--- a/lib/kitchen/reference_element.rb
+++ b/lib/kitchen/reference_element.rb
@@ -23,14 +23,5 @@ module Kitchen
       :reference
     end
 
-    # Returns true if this class represents the element for the given node
-    #
-    # @param node [Nokogiri::XML::Node] the underlying node
-    # @return [Boolean]
-    #
-    def self.is_the_element_class_for?(node, config:)
-      Selector.named(:reference).matches?(node, config: config)
-    end
-
   end
 end

--- a/lib/kitchen/reference_element.rb
+++ b/lib/kitchen/reference_element.rb
@@ -28,8 +28,8 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node)
-      node[:class] == 'reference'
+    def self.is_the_element_class_for?(node, config:)
+      Selector.named(:reference).matches?(node, config: config)
     end
 
   end

--- a/lib/kitchen/references_element_enumerator.rb
+++ b/lib/kitchen/references_element_enumerator.rb
@@ -10,7 +10,8 @@ module Kitchen
     #
     def self.factory
       ElementEnumeratorFactory.new(
-        default_css_or_xpath: '.reference', # TODO: get from config?
+        default_css_or_xpath: :reference,
+        # default_css_or_xpath: ->(config) { config.selectors.reference },
         sub_element_class: ReferenceElement,
         enumerator_class: self
       )

--- a/lib/kitchen/references_element_enumerator.rb
+++ b/lib/kitchen/references_element_enumerator.rb
@@ -10,8 +10,7 @@ module Kitchen
     #
     def self.factory
       ElementEnumeratorFactory.new(
-        default_css_or_xpath: :reference,
-        # default_css_or_xpath: ->(config) { config.selectors.reference },
+        default_css_or_xpath: Selector.named(:reference),
         sub_element_class: ReferenceElement,
         enumerator_class: self
       )

--- a/lib/kitchen/search_query.rb
+++ b/lib/kitchen/search_query.rb
@@ -36,7 +36,13 @@ module Kitchen
     end
 
     # Replaces '$' in the `css_or_xpath` with the provided value; also normalizes
-    # `css_or_xpath` to an array
+    # `css_or_xpath` to an array.
+    #
+    # @param default_css_or_xpath [String, Proc, Symbol] The selectors to substitute for the "$" character
+    #   when this factory is used to build an enumerator.  A string argument is used literally.  A proc
+    #   is eventually called given the document's Config object (for accessing selectors).  A symbol
+    #   is interpreted as the name of a selector and is called on the document's Config object's
+    #   selectors object.
     #
     def apply_default_css_or_xpath_and_normalize(default_css_or_xpath=nil, config: nil)
       return if @default_already_applied

--- a/lib/kitchen/search_query.rb
+++ b/lib/kitchen/search_query.rb
@@ -24,6 +24,7 @@ module Kitchen
       @css_or_xpath = css_or_xpath
       @only = only.is_a?(String) ? only.to_sym : only
       @except = except.is_a?(String) ? except.to_sym : except
+      @default_already_applied = false
     end
 
     # Returns true iff the element passes the `only` and `except` conditions
@@ -37,11 +38,26 @@ module Kitchen
     # Replaces '$' in the `css_or_xpath` with the provided value; also normalizes
     # `css_or_xpath` to an array
     #
-    def apply_default_css_or_xpath_and_normalize(default_css_or_xpath=nil)
+    def apply_default_css_or_xpath_and_normalize(default_css_or_xpath=nil, config: nil)
+      return if @default_already_applied
+
+      default_css_or_xpath = [default_css_or_xpath].flatten.map do |item|
+        case item
+        when Proc
+          item.call(config)
+        when Symbol
+          config.selectors.send(item)
+        else
+          item
+        end
+      end
+
       @as_type = nil
       @css_or_xpath = [css_or_xpath || '$'].flatten.map do |item|
-        item.gsub(/\$/, [default_css_or_xpath].flatten.join(', '))
+        item.gsub(/\$/, default_css_or_xpath.join(', '))
       end
+
+      @default_already_applied = true
     end
 
     # Returns the search query as a spaceless string suitable for use as an element type

--- a/lib/kitchen/selector.rb
+++ b/lib/kitchen/selector.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Kitchen
+  # A wrapper for a selector.  Can be used as the default_css_or_xpath.
+  #
+  class Selector < Proc
+    attr_reader :name
+
+    def self.named(name)
+      new(name) { |config| config.selectors.send(name) }
+    end
+
+    def initialize(name, &block)
+      @name = name
+      super(&block)
+    end
+
+    def matches?(node, config:)
+      # This may not be incredibly efficient as it does a search of this node's
+      # ancestors to see if the node is in the results.  Watch the performance.
+      node.matches?(call(config))
+    end
+  end
+end

--- a/lib/kitchen/selectors/base.rb
+++ b/lib/kitchen/selectors/base.rb
@@ -17,6 +17,9 @@ module Kitchen
       # Selector for the summary in a page
       # @return [String]
       attr_accessor :page_summary
+      # Selector for a reference
+      # @return [String]
+      attr_accessor :reference
 
       # Override specific selectors
       #

--- a/lib/kitchen/selectors/base.rb
+++ b/lib/kitchen/selectors/base.rb
@@ -35,6 +35,9 @@ module Kitchen
       # Selector for a table
       # @return [String]
       attr_accessor :table
+      # Selector for a figure
+      # @return [String]
+      attr_accessor :figure
 
       # Override specific selectors
       #

--- a/lib/kitchen/selectors/base.rb
+++ b/lib/kitchen/selectors/base.rb
@@ -20,6 +20,9 @@ module Kitchen
       # Selector for a reference
       # @return [String]
       attr_accessor :reference
+      # Selector for a chapter
+      # @return [String]
+      attr_accessor :chapter
 
       # Override specific selectors
       #

--- a/lib/kitchen/selectors/base.rb
+++ b/lib/kitchen/selectors/base.rb
@@ -23,6 +23,9 @@ module Kitchen
       # Selector for a chapter
       # @return [String]
       attr_accessor :chapter
+      # Selector for a note
+      # @return [String]
+      attr_accessor :note
 
       # Override specific selectors
       #

--- a/lib/kitchen/selectors/base.rb
+++ b/lib/kitchen/selectors/base.rb
@@ -32,6 +32,9 @@ module Kitchen
       # Selector for a term
       # @return [String]
       attr_accessor :term
+      # Selector for a table
+      # @return [String]
+      attr_accessor :table
 
       # Override specific selectors
       #

--- a/lib/kitchen/selectors/base.rb
+++ b/lib/kitchen/selectors/base.rb
@@ -44,6 +44,9 @@ module Kitchen
       # Selector for a composite page
       # @return [String]
       attr_accessor :composite_page
+      # Selector for an example
+      # @return [String]
+      attr_accessor :example
 
       # Override specific selectors
       #

--- a/lib/kitchen/selectors/base.rb
+++ b/lib/kitchen/selectors/base.rb
@@ -23,6 +23,9 @@ module Kitchen
       # Selector for a chapter
       # @return [String]
       attr_accessor :chapter
+      # Selector for a page
+      # @return [String]
+      attr_accessor :page
       # Selector for a note
       # @return [String]
       attr_accessor :note

--- a/lib/kitchen/selectors/base.rb
+++ b/lib/kitchen/selectors/base.rb
@@ -41,6 +41,9 @@ module Kitchen
       # Selector for a metadata
       # @return [String]
       attr_accessor :metadata
+      # Selector for a composite page
+      # @return [String]
+      attr_accessor :composite_page
 
       # Override specific selectors
       #

--- a/lib/kitchen/selectors/base.rb
+++ b/lib/kitchen/selectors/base.rb
@@ -38,6 +38,9 @@ module Kitchen
       # Selector for a figure
       # @return [String]
       attr_accessor :figure
+      # Selector for a metadata
+      # @return [String]
+      attr_accessor :metadata
 
       # Override specific selectors
       #

--- a/lib/kitchen/selectors/base.rb
+++ b/lib/kitchen/selectors/base.rb
@@ -44,6 +44,9 @@ module Kitchen
       # Selector for a composite page
       # @return [String]
       attr_accessor :composite_page
+      # Selector for a composite chapter
+      # @return [String]
+      attr_accessor :composite_chapter
       # Selector for an example
       # @return [String]
       attr_accessor :example

--- a/lib/kitchen/selectors/base.rb
+++ b/lib/kitchen/selectors/base.rb
@@ -47,6 +47,12 @@ module Kitchen
       # Selector for an example
       # @return [String]
       attr_accessor :example
+      # Selector for an exercise
+      # @return [String]
+      attr_accessor :exercise
+      # Selector for an unit
+      # @return [String]
+      attr_accessor :unit
 
       # Override specific selectors
       #

--- a/lib/kitchen/selectors/base.rb
+++ b/lib/kitchen/selectors/base.rb
@@ -29,6 +29,9 @@ module Kitchen
       # Selector for a note
       # @return [String]
       attr_accessor :note
+      # Selector for a term
+      # @return [String]
+      attr_accessor :term
 
       # Override specific selectors
       #

--- a/lib/kitchen/selectors/standard_1.rb
+++ b/lib/kitchen/selectors/standard_1.rb
@@ -15,6 +15,7 @@ module Kitchen
         self.page_summary               = 'section.summary'
         self.reference                  = '.reference'
         self.chapter                    = "div[data-type='chapter']"
+        self.note                       = "div[data-type='note']"
       end
 
     end

--- a/lib/kitchen/selectors/standard_1.rb
+++ b/lib/kitchen/selectors/standard_1.rb
@@ -17,6 +17,7 @@ module Kitchen
         self.chapter                    = "div[data-type='chapter']"
         self.page                       = "div[data-type='page']"
         self.note                       = "div[data-type='note']"
+        self.term                       = "span[data-type='term']"
       end
 
     end

--- a/lib/kitchen/selectors/standard_1.rb
+++ b/lib/kitchen/selectors/standard_1.rb
@@ -14,6 +14,7 @@ module Kitchen
         self.title_in_introduction_page = "./*[@data-type = 'document-title']"
         self.page_summary               = 'section.summary'
         self.reference                  = '.reference'
+        self.chapter                    = "div[data-type='chapter']"
       end
 
     end

--- a/lib/kitchen/selectors/standard_1.rb
+++ b/lib/kitchen/selectors/standard_1.rb
@@ -19,6 +19,7 @@ module Kitchen
         self.note                       = "div[data-type='note']"
         self.term                       = "span[data-type='term']"
         self.table                      = 'table'
+        self.figure                     = 'figure'
       end
 
     end

--- a/lib/kitchen/selectors/standard_1.rb
+++ b/lib/kitchen/selectors/standard_1.rb
@@ -21,6 +21,7 @@ module Kitchen
         self.table                      = 'table'
         self.figure                     = 'figure'
         self.metadata                   = "div[data-type='metadata']"
+        self.composite_page             = "div[data-type='composite-page']"
       end
 
     end

--- a/lib/kitchen/selectors/standard_1.rb
+++ b/lib/kitchen/selectors/standard_1.rb
@@ -23,6 +23,8 @@ module Kitchen
         self.metadata                   = "div[data-type='metadata']"
         self.composite_page             = "div[data-type='composite-page']"
         self.example                    = "div[data-type='example']"
+        self.exercise                   = "div[data-type='exercise']"
+        self.unit                       = "div[data-type='unit']"
       end
 
     end

--- a/lib/kitchen/selectors/standard_1.rb
+++ b/lib/kitchen/selectors/standard_1.rb
@@ -22,6 +22,7 @@ module Kitchen
         self.figure                     = 'figure'
         self.metadata                   = "div[data-type='metadata']"
         self.composite_page             = "div[data-type='composite-page']"
+        self.example                    = "div[data-type='example']"
       end
 
     end

--- a/lib/kitchen/selectors/standard_1.rb
+++ b/lib/kitchen/selectors/standard_1.rb
@@ -18,6 +18,7 @@ module Kitchen
         self.page                       = "div[data-type='page']"
         self.note                       = "div[data-type='note']"
         self.term                       = "span[data-type='term']"
+        self.table                      = 'table'
       end
 
     end

--- a/lib/kitchen/selectors/standard_1.rb
+++ b/lib/kitchen/selectors/standard_1.rb
@@ -15,6 +15,7 @@ module Kitchen
         self.page_summary               = 'section.summary'
         self.reference                  = '.reference'
         self.chapter                    = "div[data-type='chapter']"
+        self.page                       = "div[data-type='page']"
         self.note                       = "div[data-type='note']"
       end
 

--- a/lib/kitchen/selectors/standard_1.rb
+++ b/lib/kitchen/selectors/standard_1.rb
@@ -20,6 +20,7 @@ module Kitchen
         self.term                       = "span[data-type='term']"
         self.table                      = 'table'
         self.figure                     = 'figure'
+        self.metadata                   = "div[data-type='metadata']"
       end
 
     end

--- a/lib/kitchen/selectors/standard_1.rb
+++ b/lib/kitchen/selectors/standard_1.rb
@@ -22,6 +22,7 @@ module Kitchen
         self.figure                     = 'figure'
         self.metadata                   = "div[data-type='metadata']"
         self.composite_page             = "div[data-type='composite-page']"
+        self.composite_chapter          = "div[data-type='composite-chapter']"
         self.example                    = "div[data-type='example']"
         self.exercise                   = "div[data-type='exercise']"
         self.unit                       = "div[data-type='unit']"

--- a/lib/kitchen/selectors/standard_1.rb
+++ b/lib/kitchen/selectors/standard_1.rb
@@ -13,6 +13,7 @@ module Kitchen
         self.title_in_page              = "./*[@data-type = 'document-title']"
         self.title_in_introduction_page = "./*[@data-type = 'document-title']"
         self.page_summary               = 'section.summary'
+        self.reference                  = '.reference'
       end
 
     end

--- a/lib/kitchen/table_element.rb
+++ b/lib/kitchen/table_element.rb
@@ -80,14 +80,5 @@ module Kitchen
       first('caption')
     end
 
-    # Returns true if this class represents the element for the given node
-    #
-    # @param node [Nokogiri::XML::Node] the underlying node
-    # @return [Boolean]
-    #
-    def self.is_the_element_class_for?(node, config:)
-      Selector.named(:table).matches?(node, config: config)
-    end
-
   end
 end

--- a/lib/kitchen/table_element.rb
+++ b/lib/kitchen/table_element.rb
@@ -85,7 +85,7 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node)
+    def self.is_the_element_class_for?(node, **)
       node.name == 'table'
     end
 

--- a/lib/kitchen/table_element.rb
+++ b/lib/kitchen/table_element.rb
@@ -85,8 +85,8 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node, **)
-      node.name == 'table'
+    def self.is_the_element_class_for?(node, config:)
+      Selector.named(:table).matches?(node, config: config)
     end
 
   end

--- a/lib/kitchen/table_element_enumerator.rb
+++ b/lib/kitchen/table_element_enumerator.rb
@@ -11,7 +11,7 @@ module Kitchen
     #
     def self.factory
       ElementEnumeratorFactory.new(
-        default_css_or_xpath: 'table', # TODO: get from config?
+        default_css_or_xpath: Selector.named(:table),
         sub_element_class: TableElement,
         enumerator_class: self
       )

--- a/lib/kitchen/term_element.rb
+++ b/lib/kitchen/term_element.rb
@@ -28,7 +28,7 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node)
+    def self.is_the_element_class_for?(node, **)
       node['data-type'] == 'term'
     end
 

--- a/lib/kitchen/term_element.rb
+++ b/lib/kitchen/term_element.rb
@@ -23,14 +23,5 @@ module Kitchen
       :term
     end
 
-    # Returns true if this class represents the element for the given node
-    #
-    # @param node [Nokogiri::XML::Node] the underlying node
-    # @return [Boolean]
-    #
-    def self.is_the_element_class_for?(node, config:)
-      Selector.named(:term).matches?(node, config: config)
-    end
-
   end
 end

--- a/lib/kitchen/term_element.rb
+++ b/lib/kitchen/term_element.rb
@@ -28,8 +28,8 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node, **)
-      node['data-type'] == 'term'
+    def self.is_the_element_class_for?(node, config:)
+      Selector.named(:term).matches?(node, config: config)
     end
 
   end

--- a/lib/kitchen/term_element_enumerator.rb
+++ b/lib/kitchen/term_element_enumerator.rb
@@ -11,7 +11,7 @@ module Kitchen
     #
     def self.factory
       ElementEnumeratorFactory.new(
-        default_css_or_xpath: "span[data-type='term']", # TODO: get from config?
+        default_css_or_xpath: Selector.named(:term),
         sub_element_class: TermElement,
         enumerator_class: self
       )

--- a/lib/kitchen/unit_element.rb
+++ b/lib/kitchen/unit_element.rb
@@ -41,13 +41,5 @@ module Kitchen
       title.children.one? ? title.text : title.first('.os-text').text
     end
 
-    # Returns true if this class represents the element for the given node
-    #
-    # @param node [Nokogiri::XML::Node] the underlying node
-    # @return [Boolean]
-    #
-    def self.is_the_element_class_for?(node, config:)
-      Selector.named(:unit).matches?(node, config: config)
-    end
   end
 end

--- a/lib/kitchen/unit_element.rb
+++ b/lib/kitchen/unit_element.rb
@@ -46,8 +46,8 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node, **)
-      node['data-type'] == 'unit'
+    def self.is_the_element_class_for?(node, config:)
+      Selector.named(:unit).matches?(node, config: config)
     end
   end
 end

--- a/lib/kitchen/unit_element.rb
+++ b/lib/kitchen/unit_element.rb
@@ -46,7 +46,7 @@ module Kitchen
     # @param node [Nokogiri::XML::Node] the underlying node
     # @return [Boolean]
     #
-    def self.is_the_element_class_for?(node)
+    def self.is_the_element_class_for?(node, **)
       node['data-type'] == 'unit'
     end
   end

--- a/lib/kitchen/unit_element_enumerator.rb
+++ b/lib/kitchen/unit_element_enumerator.rb
@@ -11,7 +11,7 @@ module Kitchen
     #
     def self.factory
       ElementEnumeratorFactory.new(
-        default_css_or_xpath: "div[data-type='unit']",
+        default_css_or_xpath: Selector.named(:unit),
         sub_element_class: UnitElement,
         enumerator_class: self
       )

--- a/lib/openstax_kitchen.rb
+++ b/lib/openstax_kitchen.rb
@@ -40,6 +40,7 @@ require 'kitchen/oven'
 require 'kitchen/clipboard'
 require 'kitchen/pantry'
 require 'kitchen/counter'
+require 'kitchen/selector'
 
 require 'kitchen/element_enumerator_base'
 require 'kitchen/element_enumerator_factory'

--- a/spec/search_query_spec.rb
+++ b/spec/search_query_spec.rb
@@ -36,11 +36,23 @@ RSpec.describe Kitchen::SearchQuery do
     it 'adds a $ when css nil' do
       expect_normalization(default_css_or_xpath: 'div', to: ['div'])
     end
+
+    it 'works with a proc' do
+      expect_normalization(default_css_or_xpath: ->(config) { config.selectors.reference },
+                           config: Kitchen::Config.new.tap { |config| config.selectors.reference = 'foo' },
+                           to: ['foo'])
+    end
+
+    it 'works with a symbol' do
+      expect_normalization(default_css_or_xpath: :reference,
+                           config: Kitchen::Config.new.tap { |config| config.selectors.reference = 'foo' },
+                           to: ['foo'])
+    end
   end
 
-  def expect_normalization(to:, css_or_xpath: nil, default_css_or_xpath: nil)
+  def expect_normalization(to:, css_or_xpath: nil, default_css_or_xpath: nil, config: nil)
     instance = described_class.new(css_or_xpath: css_or_xpath)
-    instance.apply_default_css_or_xpath_and_normalize(default_css_or_xpath)
+    instance.apply_default_css_or_xpath_and_normalize(default_css_or_xpath, config: config)
     expect(instance.css_or_xpath).to eq to
   end
 


### PR DESCRIPTION
The selectors object within a document's config object is intended to be a common place to store all of the main CSS or XPath selectors, e.g. those that define chapters, notes, pages, etc.

A nice thing about such a common place is that it gives us easy access to override the selectors to account for book-by-book differences.  E.g. some books identify references with a "reference" class (singular), while others use a "references" class (plural).  

Really using the selectors means we need to be able to use them from enumerators.  When enumerators are used and chained, we don't immediately have access to the config object which contains the selectors -- we don't get that access until we are actually running a search on an element and can get to the config via the element's document.  

When we define an enumerator, we define its `default_css_or_xpath`, e.g. `[data-type="page"]`.  So that we can define this value in the selectors and use them down in the guts of enumeration, this PR changes the `default_css_or_xpath` to optionally be a `Proc`, aka a little function that can accept the `config` object and call `config.selectors.something` when the `config` object is available.

You can pass these Procs into the `ElementEnumeratorFactory` directly, e.g. 

```ruby
ElementEnumeratorFactory.new(
  default_css_or_xpath: ->(config) { config.selectors.reference},
  sub_element_class: PageElement,
  enumerator_class: self
)
```

or you can use the new `Selector` class to give you such a `Proc` in a neater form:

```ruby
default_css_or_xpath: Selector.named(:reference)
```

A bonus of this new `Selector` object is that we can also use it to implement the `is_the_element_class_for?` method without duplicating selector values, e.g.

```ruby
def self.is_the_element_class_for?(node, config:)
  Selector.named(:reference).matches?(node, config: config)
end
```

A lot of the files in this PR changed only to account for the new `config:` argument to `is_the_element_class_for?`.