### PR TITLE
a quicker alternative to Node::matches? based on existing nokogiri parser

### DIFF
--- a/lib/kitchen/patches/nokogiri.rb
+++ b/lib/kitchen/patches/nokogiri.rb
@@ -43,6 +43,40 @@ module Nokogiri
       def inspect
         to_s
       end
+
+      def quick_matches?(selector)
+        Nokogiri::CSS::Parser.new.parse(selector).any? { |css_node| matches_css_node?(css_node) }
+      end
+
+      def classes
+        self[:class]&.split || []
+      end
+
+      private
+
+      # rubocop:disable Metrics/CyclomaticComplexity
+      def matches_css_node?(css_node)
+        case css_node.type
+        when :CONDITIONAL_SELECTOR
+          css_node.value.all? { |inner_css_node| matches_css_node?(inner_css_node) }
+        when :ELEMENT_NAME
+          css_node.value == ['*'] || css_node.value.include?(name)
+        when :CLASS_CONDITION
+          (css_node.value & classes).any?
+        when :ATTRIBUTE_CONDITION
+          attribute, operator, value = css_node.value
+
+          raise "Unknown attribute condition operator in #{css_node}" if operator != :equal
+
+          attribute_name = attribute.value
+          raise "More attribute names than expected, #{attribute_name}" if attribute_name.many?
+
+          self[attribute_name.first] == value.gsub('"', '').gsub("'", '')
+        else
+          raise "Unknown Nokogiri::CSS:Node type in #{css_node}"
+        end
+      end
+      # rubocop:enable Metrics/CyclomaticComplexity
     end
   end
 end

--- a/lib/kitchen/patches/nokogiri.rb
+++ b/lib/kitchen/patches/nokogiri.rb
@@ -45,14 +45,20 @@ module Nokogiri
       end
 
       def quick_matches?(selector)
-        Nokogiri::CSS::Parser.new.parse(selector).any? { |css_node| matches_css_node?(css_node) }
+        self.class.selector_to_css_nodes(selector).any? { |css_node| matches_css_node?(css_node) }
       end
 
       def classes
         self[:class]&.split || []
       end
 
-      private
+      def self.selector_to_css_nodes(selector)
+        # No need to parse the same selector more than once.
+        @parsed_selectors ||= {}
+        @parsed_selectors[selector] ||= Nokogiri::CSS::Parser.new.parse(selector)
+      end
+
+      protected
 
       # rubocop:disable Metrics/CyclomaticComplexity
       def matches_css_node?(css_node)

--- a/lib/kitchen/selector.rb
+++ b/lib/kitchen/selector.rb
@@ -18,7 +18,7 @@ module Kitchen
     def matches?(node, config:)
       # This may not be incredibly efficient as it does a search of this node's
       # ancestors to see if the node is in the results.  Watch the performance.
-      node.matches?(call(config))
+      node.quick_matches?(call(config))
     end
   end
 end

--- a/spec/patches/nokogiri_spec.rb
+++ b/spec/patches/nokogiri_spec.rb
@@ -27,5 +27,59 @@ RSpec.describe 'Nokogiri patches' do
       expect_any_instance_of(Nokogiri::XML::Node).to receive(:to_s)
       document.search('div').first.inspect
     end
+
+    it 'gives an array of classes' do
+      expect(make_nokogiri_node('<div class="foo"/>').classes).to eq ['foo']
+      expect(make_nokogiri_node('<div class="foo bar"/>').classes).to eq %w[foo bar]
+      expect(make_nokogiri_node('<div/>').classes).to eq []
+    end
+
+    describe '#quick_matches?' do
+      it 'works for simple name selectors' do
+        expect(make_nokogiri_node('<div/>').quick_matches?('div')).to be true
+        expect(make_nokogiri_node('<div/>').quick_matches?('span')).to be false
+      end
+
+      it 'works for simple name selectors with a class' do
+        expect(make_nokogiri_node('<div class="bar foo"/>').quick_matches?('div.foo')).to be true
+        expect(make_nokogiri_node('<div class="bar foo"/>').quick_matches?('div.bar')).to be true
+        expect(make_nokogiri_node('<div class="bar foo"/>').quick_matches?('div.blah')).to be false
+      end
+
+      it 'does not explode for class selectors when there is no class' do
+        expect(make_nokogiri_node('<div/>').quick_matches?('div.foo')).to be false
+      end
+
+      it 'works for attributes with element name' do
+        expect(make_nokogiri_node('<div data-type="foo"/>').quick_matches?('div[data-type="foo"]')).to be true
+        expect(make_nokogiri_node('<div data-type="foo"/>').quick_matches?('div[data-type="bar"]')).to be false
+      end
+
+      it 'works for attributes without element name' do
+        expect(make_nokogiri_node('<div data-type="foo"/>').quick_matches?('[data-type="foo"]')).to be true
+        expect(make_nokogiri_node('<div data-type="foo"/>').quick_matches?('[data-type="bar"]')).to be false
+      end
+
+      it 'works for multiple selectors' do
+        expect(make_nokogiri_node('<div class="bar"/>').quick_matches?('.foo, .bar')).to be true
+        expect(make_nokogiri_node('<div class="bar"/>').quick_matches?('.foo, .blah')).to be false
+      end
+
+      it 'freaks out if it gets a type it does not know' do
+        expect {
+          make_nokogiri_node('<div class="bar"/>').quick_matches?('.foo > .bar')
+        }.to raise_error(/Unknown.*type/)
+      end
+    end
+  end
+
+  def make_nokogiri_node(string)
+    Nokogiri::XML(
+      <<~XML
+        <div>
+          #{string}
+        </div>
+      XML
+    ).search('div').first.element_children.first
   end
 end


### PR DESCRIPTION
This is similar to what we discussed on a call today except it uses Nokogiri's built-in CSS parser.  May end up slower than the regular express approach.