### PR TITLE
use specific selectors to shave seconds off of whole book bake time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Adds low level Nokogiri caching, disabled by default (patch)
 * Cache Selector objects since they don't change (patch)
+* Use more specific selectors when baking composite chapters and pages (patch)
 
 ## [4.1.0] - 2021-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Adds low level Nokogiri caching, disabled by default (patch)
 * Cache Selector objects since they don't change (patch)
-* Use more specific selectors when baking composite chapters and pages (patch)
+* Use more specific selectors when to reduce bake time (patch)
 
 ## [4.1.0] - 2021-05-18
 

--- a/lib/kitchen/book_document.rb
+++ b/lib/kitchen/book_document.rb
@@ -29,7 +29,7 @@ module Kitchen
     # @return [BookElement]
     #
     def book
-      BookElement.new(node: nokogiri_document.search('html').first, document: self)
+      BookElement.new(node: nokogiri_document.root, document: self)
     end
 
   end

--- a/lib/kitchen/chapter_element.rb
+++ b/lib/kitchen/chapter_element.rb
@@ -41,7 +41,7 @@ module Kitchen
     # @return [Element, nil]
     #
     def introduction_page
-      pages('.introduction').first
+      pages('$.introduction').first
     end
 
     # Returns an enumerator for the glossaries

--- a/lib/kitchen/chapter_element.rb
+++ b/lib/kitchen/chapter_element.rb
@@ -65,7 +65,7 @@ module Kitchen
     # @return [ElementEnumerator]
     #
     def abstracts
-      search('[data-type="abstract"]')
+      search('div[data-type="abstract"]')
     end
 
   end

--- a/lib/kitchen/composite_chapter_element_enumerator.rb
+++ b/lib/kitchen/composite_chapter_element_enumerator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Kitchen
+  # An enumerator for composite page elements
+  #
+  class CompositeChapterElementEnumerator < ElementEnumeratorBase
+
+    # Returns a factory for this enumerator
+    #
+    # @return [ElementEnumeratorFactory]
+    #
+    def self.factory
+      ElementEnumeratorFactory.new(
+        default_css_or_xpath: Selector.named(:composite_chapter),
+        sub_element_class: CompositeChapterElement,
+        enumerator_class: self
+      )
+    end
+
+  end
+end

--- a/lib/kitchen/directions/bake_chapter_key_concepts/v1.rb
+++ b/lib/kitchen/directions/bake_chapter_key_concepts/v1.rb
@@ -19,7 +19,7 @@ module Kitchen::Directions::BakeChapterKeyConcepts
         key_concepts.each do |key_concept|
           key_concept.prepend(child: title)
           key_concept.wrap("<div class='os-section-area'>")
-          page.search('.os-section-area').first.cut(to: key_concepts_clipboard)
+          page.search('div.os-section-area').first.cut(to: key_concepts_clipboard)
         end
       end
 

--- a/lib/kitchen/directions/bake_composite_chapters.rb
+++ b/lib/kitchen/directions/bake_composite_chapters.rb
@@ -4,7 +4,7 @@ module Kitchen
   module Directions
     module BakeCompositeChapters
       def self.v1(book:)
-        book.search("[data-type='composite-chapter']").each do |chapter|
+        book.composite_chapters.each do |chapter|
           chapter.first("[data-type='document-title']").id =
             "composite-chapter-#{chapter.count_in(:book)}"
         end

--- a/lib/kitchen/directions/bake_composite_pages.rb
+++ b/lib/kitchen/directions/bake_composite_pages.rb
@@ -4,7 +4,7 @@ module Kitchen
   module Directions
     module BakeCompositePages
       def self.v1(book:)
-        book.search("[data-type='composite-page']").each do |page|
+        book.composite_pages.each do |page|
           page.id = "composite-page-#{page.count_in(:book)}"
         end
       end

--- a/lib/kitchen/directions/bake_equations.rb
+++ b/lib/kitchen/directions/bake_equations.rb
@@ -4,7 +4,7 @@ module Kitchen
   module Directions
     module BakeEquations
       def self.v1(book:, number_decorator: :none)
-        book.chapters.search('[data-type="equation"]:not(.unnumbered)').each do |eq|
+        book.chapters.search('div[data-type="equation"]:not(.unnumbered)').each do |eq|
           chapter = eq.ancestor(:chapter)
           number = "#{chapter.count_in(:book)}.#{eq.count_in(:chapter)}"
 

--- a/lib/kitchen/directions/book_answer_key_container/v1.rb
+++ b/lib/kitchen/directions/book_answer_key_container/v1.rb
@@ -7,7 +7,7 @@ module Kitchen::Directions::BookAnswerKeyContainer
     def bake(book:)
       @metadata = book.metadata.children_to_keep.copy
       book.body.append(child: render(file: 'eob_solutions_container.xhtml.erb'))
-      book.body.first('.os-eob.os-solutions-container')
+      book.body.first('div.os-eob.os-solutions-container')
     end
   end
 end

--- a/lib/kitchen/directions/chapter_review_container/v1.rb
+++ b/lib/kitchen/directions/chapter_review_container/v1.rb
@@ -7,7 +7,7 @@ module Kitchen::Directions::ChapterReviewContainer
     def bake(chapter:, metadata_source:)
       @metadata = metadata_source.children_to_keep.copy
       chapter.append(child: render(file: 'chapter_review.xhtml.erb'))
-      chapter.first('.os-eoc.os-chapter-review-container')
+      chapter.first('div.os-eoc.os-chapter-review-container')
     end
   end
 end

--- a/lib/kitchen/directions/move_solutions_to_answer_key/strategies/uphysics.rb
+++ b/lib/kitchen/directions/move_solutions_to_answer_key/strategies/uphysics.rb
@@ -18,7 +18,7 @@ module Kitchen::Directions::MoveSolutionsToAnswerKey
       def bake_section(chapter:, append_to:, klass:)
         section_solutions_set = []
         chapter.search(".#{klass}").each do |section|
-          section.search('[data-type="solution"]').each do |solution|
+          section.search('div[data-type="solution"]').each do |solution|
             section_solutions_set.push(solution.cut)
           end
         end

--- a/lib/kitchen/directions/move_solutions_to_answer_key/strategies/uphysics.rb
+++ b/lib/kitchen/directions/move_solutions_to_answer_key/strategies/uphysics.rb
@@ -31,7 +31,7 @@ module Kitchen::Directions::MoveSolutionsToAnswerKey
 
       def bake_from_notes(chapter:, append_to:, klass:)
         solutions = []
-        chapter.notes(".#{klass}").each do |note|
+        chapter.notes("$.#{klass}").each do |note|
           note.exercises.each do |exercise|
             solution = exercise.solution
             solutions.push(solution.cut) if solution

--- a/lib/kitchen/document.rb
+++ b/lib/kitchen/document.rb
@@ -47,16 +47,8 @@ module Kitchen
       @next_paste_count_for_id = {}
       @id_copy_suffix = '_copy_'
 
-      # Nokogiri by default only recognizes the namespaces on the root node.  Collect all
-      # namespaces and add them manually.
-      return unless @config.enable_all_namespaces && raw.present?
-
-      raw.collect_namespaces.each do |namespace, url|
-        prefix, name = namespace.split(':')
-        next unless prefix == 'xmlns' && name.present?
-
-        raw.root.add_namespace_definition(name, url)
-      end
+      # Nokogiri by default only recognizes the namespaces on the root node.  Add all others.
+      raw&.add_all_namespaces! if @config.enable_all_namespaces
     end
 
     # Returns an enumerator that iterates over all children of this document

--- a/lib/kitchen/element_base.rb
+++ b/lib/kitchen/element_base.rb
@@ -706,7 +706,7 @@ module Kitchen
     #   Returns a pages enumerator
     def_delegators :as_enumerator, :pages, :chapters, :terms, :figures, :notes, :tables, :examples,
                    :metadatas, :non_introduction_pages, :units, :titles, :exercises, :references,
-                   :composite_pages
+                   :composite_pages, :composite_chapters
 
     # Returns this element as an enumerator (over only one element, itself)
     #

--- a/lib/kitchen/element_enumerator_base.rb
+++ b/lib/kitchen/element_enumerator_base.rb
@@ -84,7 +84,30 @@ module Kitchen
     #
     def composite_pages(css_or_xpath=nil, only: nil, except: nil)
       block_error_if(block_given?)
-      chain_to(CompositePageElementEnumerator, css_or_xpath: css_or_xpath, only: only, except: except)
+      chain_to(CompositePageElementEnumerator,
+               css_or_xpath: css_or_xpath,
+               only: only,
+               except: except)
+    end
+
+    # Returns an enumerator that iterates through composite chapters within the scope of this enumerator
+    #
+    # @param css_or_xpath [String] additional selectors to further narrow the element iterated over;
+    #   a "$" in this argument will be replaced with the default selector for the element being
+    #   iterated over.
+    # @param only [Symbol, Callable] the name of a method to call on an element or a
+    #   lambda or proc that accepts an element; elements will only be included in the
+    #   search results if the method or callable returns true
+    # @param except [Symbol, Callable] the name of a method to call on an element or a
+    #   lambda or proc that accepts an element; elements will not be included in the
+    #   search results if the method or callable returns false
+    #
+    def composite_chapters(css_or_xpath=nil, only: nil, except: nil)
+      block_error_if(block_given?)
+      chain_to(CompositeChapterElementEnumerator,
+               css_or_xpath: css_or_xpath,
+               only: only,
+               except: except)
     end
 
     # Returns an enumerator that iterates through pages that arent the introduction page within the scope of this enumerator

--- a/lib/kitchen/element_enumerator_factory.rb
+++ b/lib/kitchen/element_enumerator_factory.rb
@@ -46,6 +46,12 @@ module Kitchen
                              search_query: search_query,
                              reload: reload)
       when ElementEnumeratorBase
+        if enumerator_class != ElementEnumerator && !search_query.expects_substitution?
+          raise "Query #{search_query} is missing the substituion character ('$') but " \
+                "is run with an enumerator #{enumerator_class.name} that has its own " \
+                "selectors for substitution."
+        end
+
         build_within_other_enumerator(enumerator_or_element,
                                       search_query: search_query,
                                       reload: reload)

--- a/lib/kitchen/element_enumerator_factory.rb
+++ b/lib/kitchen/element_enumerator_factory.rb
@@ -47,7 +47,7 @@ module Kitchen
                              reload: reload)
       when ElementEnumeratorBase
         if enumerator_class != ElementEnumerator && !search_query.expects_substitution?
-          raise "Query #{search_query} is missing the substituion character ('$') but " \
+          raise "Query #{search_query} is missing the substitution character ('$') but " \
                 "is run with an enumerator #{enumerator_class.name} that has its own " \
                 "selectors for substitution."
         end

--- a/lib/kitchen/exercise_element.rb
+++ b/lib/kitchen/exercise_element.rb
@@ -28,7 +28,7 @@ module Kitchen
     # @return ElementEnumerator
     #
     def problem
-      first("[data-type='problem']")
+      first("div[data-type='problem']")
     end
 
     # Returns the enumerator for solution.
@@ -36,7 +36,7 @@ module Kitchen
     # @return ElementEnumerator
     #
     def solution
-      first("[data-type='solution']")
+      first("div[data-type='solution']")
     end
   end
 end

--- a/lib/kitchen/patches/nokogiri.rb
+++ b/lib/kitchen/patches/nokogiri.rb
@@ -31,6 +31,21 @@ module Nokogiri
           end
         end
       end
+
+      def add_all_namespaces!
+        # Nokogiri by default only recognizes the namespaces on the root node.  Collect all
+        # namespaces and add them manually.
+        return if @all_namespaces_added
+
+        collect_namespaces.each do |namespace, url|
+          prefix, name = namespace.split(':')
+          next unless prefix == 'xmlns' && name.present?
+
+          root.add_namespace_definition(name, url)
+        end
+
+        @all_namespaces_added = true
+      end
     end
 
     # Monkey patches for Nokogiri::XML::Node

--- a/lib/kitchen/patches/nokogiri_profiling.rb
+++ b/lib/kitchen/patches/nokogiri_profiling.rb
@@ -10,6 +10,8 @@ module Nokogiri
     # rubocop:enable Style/MutableConstant
 
     if ENV['PROFILE']
+      ENV['VERBOSE_PROFILE'] = 1 if ENV['PROFILE'].to_s.downcase == 'verbose'
+
       # Patches inside Nokogiri to count, time, and print searches.  At end of baking
       # you can `puts Nokogiri::XML::PROFILE_DATA` to see the totals.  The counts
       # hash is defined outside of the if block so that code that prints it doesn't
@@ -40,7 +42,7 @@ module Nokogiri
       class XPathContext
         alias_method :original_evaluate, :evaluate
         def evaluate(search_path, handler=nil)
-          puts search_path
+          puts search_path if ENV['VERBOSE_PROFILE']
 
           PROFILE_DATA[search_path] ||= Hash.new(0)
           PROFILE_DATA[search_path][:count] += 1

--- a/lib/kitchen/search_query.rb
+++ b/lib/kitchen/search_query.rb
@@ -82,6 +82,12 @@ module Kitchen
       as_type
     end
 
+    # Returns true if the query has the substitution character ('$')
+    #
+    def expects_substitution?
+      css_or_xpath.nil? || [css_or_xpath].flatten.all? { |item| item.include?('$') }
+    end
+
     protected
 
     def condition_passes?(method_or_callable, element, success_outcome)

--- a/spec/element_enumerator_factory_spec.rb
+++ b/spec/element_enumerator_factory_spec.rb
@@ -3,6 +3,10 @@
 require 'spec_helper'
 
 RSpec.describe Kitchen::ElementEnumeratorFactory do
+  let(:element1) do
+    chapter_element('<p>Hi!</p>')
+  end
+
   describe 'specific enumerators create a factory' do
     [
       Kitchen::ChapterElementEnumerator,
@@ -22,5 +26,11 @@ RSpec.describe Kitchen::ElementEnumeratorFactory do
         enumerator_class.factory
       end
     end
+  end
+
+  it 'raises when a specific enumerator has CSS missing the substitution character' do
+    expect {
+      element1.pages('.foo') # should be '$.foo' otherwise no point to using `pages`
+    }.to raise_error(/is missing the substitution character/)
   end
 end


### PR DESCRIPTION
Adding the `div` makes the query faster, so we should try to use more specific selectors as we can.

Also adds a check to make sure that we are adding the `$` as needed.  Prints errors like this:

> Query .introduction is missing the substituion character ('$') but is run with an enumerator Kitchen::PageElementEnumerator that has its own selectors for substitution.