### PR TITLE
Rm table summary attr in numbered tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Moved selectors from recipe to kitchen on `BakeFirstElements` Direction (minor)
 * Auto-detect language based on document; force output encoding to UTF-8 (major)
 * Switched to using a library to sort strings in a language-specific way (patch)
+* Remove summary attribute from `BakeNumberedTable` (major)
 
 ## [4.1.1] - 2021-05-24
 

--- a/lib/kitchen/directions/bake_numbered_table/v1.rb
+++ b/lib/kitchen/directions/bake_numbered_table/v1.rb
@@ -26,7 +26,6 @@ module Kitchen::Directions::BakeNumberedTable
       caption_title = ''
 
       if (title = table.first("span[data-type='title']")&.cut)
-        # new_summary += title.text
         caption_title = <<~HTML
           \n<span class="os-title" data-type="title">#{title.children}</span>
         HTML

--- a/lib/kitchen/directions/bake_numbered_table/v1.rb
+++ b/lib/kitchen/directions/bake_numbered_table/v1.rb
@@ -22,21 +22,17 @@ module Kitchen::Directions::BakeNumberedTable
       table.parent.add_class('os-column-header-container') if table.column_header?
 
       # TODO: extra spaces added here to match legacy implementation, but probably not meaningful?
-      new_summary = "#{table_label} "
       new_caption = ''
       caption_title = ''
 
       if (title = table.first("span[data-type='title']")&.cut)
-        new_summary += title.text
+        # new_summary += title.text
         caption_title = <<~HTML
           \n<span class="os-title" data-type="title">#{title.children}</span>
         HTML
       end
 
-      new_summary += ' '
-
       if (caption = table.caption&.cut)
-        new_summary += caption.text
         new_caption = <<~HTML
           \n<span class="os-caption">#{caption.children}</span>
         HTML
@@ -45,8 +41,6 @@ module Kitchen::Directions::BakeNumberedTable
           \n<span class="os-caption"></span>
         HTML
       end
-
-      table[:summary] = new_summary
 
       return if table.unnumbered?
 

--- a/spec/directions/bake_numbered_table/v1_spec.rb
+++ b/spec/directions/bake_numbered_table/v1_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Kitchen::Directions::BakeNumberedTable::V1 do
     book_containing(html:
       one_chapter_with_one_page_containing(
         <<~HTML
-          <table class="top-titled" id="tId" summary="Some summary">
+          <table class="top-titled" id="tId">
             #{caption}
             <thead>
               <tr>
@@ -42,7 +42,7 @@ RSpec.describe Kitchen::Directions::BakeNumberedTable::V1 do
     book_containing(html:
       one_chapter_with_one_page_containing(
         <<~HTML
-          <table class="column-header" id="tId" summary="column header summary">
+          <table class="column-header" id="tId">
           </table>
         HTML
       )
@@ -53,7 +53,7 @@ RSpec.describe Kitchen::Directions::BakeNumberedTable::V1 do
     book_containing(html:
       one_chapter_with_one_page_containing(
         <<~HTML
-          <table class="some-class" id="tId" summary="Some summary">
+          <table class="some-class" id="tId">
             #{caption}
             <thead>
               <tr>
@@ -78,7 +78,7 @@ RSpec.describe Kitchen::Directions::BakeNumberedTable::V1 do
     book_containing(html:
       one_chapter_with_one_page_containing(
         <<~HTML
-          <table class="some-class" id="tId" summary="Some summary">
+          <table class="some-class" id="tId">
             #{caption_with_title}
             <thead>
               <tr>
@@ -106,7 +106,7 @@ RSpec.describe Kitchen::Directions::BakeNumberedTable::V1 do
       <<~HTML
         <div class="os-table os-top-titled-container">
           <div class="os-table-title">A title</div>
-          <table class="top-titled" id="tId" summary="Table 2.3  A caption">
+          <table class="top-titled" id="tId">
             <thead>
               <tr>
                 <th>Another heading cell</th>
@@ -136,7 +136,7 @@ RSpec.describe Kitchen::Directions::BakeNumberedTable::V1 do
     expect(column_header_table.document.search('.os-table').first).to match_normalized_html(
       <<~HTML
         <div class="os-table os-column-header-container">
-          <table class="column-header" id="tId" summary="Table 2.3  ">
+          <table class="column-header" id="tId">
         </table>
           <div class="os-caption-container">
             <span class="os-title-label">Table </span>
@@ -155,7 +155,7 @@ RSpec.describe Kitchen::Directions::BakeNumberedTable::V1 do
     expect(other_table.document.search('.os-table').first).to match_normalized_html(
       <<~HTML
         <div class="os-table">
-          <table class="some-class" id="tId" summary="Table 2.3  A caption">
+          <table class="some-class" id="tId">
             <thead>
               <tr>
                 <th>A title</th>
@@ -188,7 +188,7 @@ RSpec.describe Kitchen::Directions::BakeNumberedTable::V1 do
     expect(table_with_caption_title.document.search('.os-table').first).to match_normalized_html(
       <<~HTML
         <div class="os-table">
-          <table class="some-class" id="tId" summary="Table 2.3 Secret Title A caption">
+          <table class="some-class" id="tId">
             <thead>
               <tr>
                 <th>A title</th>
@@ -233,7 +233,7 @@ RSpec.describe Kitchen::Directions::BakeNumberedTable::V1 do
       expect(column_header_table.document.search('.os-table').first).to match_normalized_html(
         <<~HTML
           <div class="os-table os-column-header-container">
-            <table class="column-header" id="tId" summary="Table 2.3  ">
+            <table class="column-header" id="tId">
           </table>
             <div class="os-caption-container">
               <span class="os-title-label">Table </span>


### PR DESCRIPTION
[Conversation and decision here ](https://openstax.slack.com/archives/C022NETP39N/p1621960840206100)
Currently, unnumbered tables did not have the summary attribute but numbered tables should also not have table attribute anymore 