### PR TITLE
Fix for index when words start with number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 and from v2 the lack of additional "os-section-area" and os-#{@klass} wrapper (minor)
 * Add a condition in BakeNumberedExercise to make it possible to suppress even solutions in the Answer Key (minor)
 * Fix BakeFurtherResearch baking with main bake script error by breaking the loop if further research sections are not present (minor)
+* Fix for `BakeIndex` for words that start with a number (minor)
 
 ## [5.0.0] - 2021-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 and from v2 the lack of additional "os-section-area" and os-#{@klass} wrapper (minor)
 * Add a condition in BakeNumberedExercise to make it possible to suppress even solutions in the Answer Key (minor)
 * Fix BakeFurtherResearch baking with main bake script error by breaking the loop if further research sections are not present (minor)
-* Fix for `BakeIndex` for words that start with a number (minor)
+* Fix for `BakeIndex` for words that start with a number (major)
 
 ## [5.0.0] - 2021-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 and from v2 the lack of additional "os-section-area" and os-#{@klass} wrapper (minor)
 * Add a condition in BakeNumberedExercise to make it possible to suppress even solutions in the Answer Key (minor)
 * Fix BakeFurtherResearch baking with main bake script error by breaking the loop if further research sections are not present (minor)
-* Fix for `BakeIndex` for words that start with a number (major)
+* Fix for `BakeIndex` for words that start with a number to be grouped as symbols and for first letters with accent marks to be grouped with regular letters in alphabetic order (major)
 
 ## [5.0.0] - 2021-06-02
 

--- a/lib/kitchen/directions/bake_index/v1.rb
+++ b/lib/kitchen/directions/bake_index/v1.rb
@@ -136,8 +136,9 @@ module Kitchen::Directions::BakeIndex
     end
 
     def add_term_to_index(term_element, page_title)
-      group_by = term_element.text.strip[0]
-      group_by = I18n.t(:eob_index_symbols_group) unless group_by.match?(/[a-zA-Z]/)
+      # group_by = term_element.text.strip[0]
+      group_by = I18n.transliterate(term_element.text.strip[0])
+      group_by = I18n.t(:eob_index_symbols_group) unless group_by.match?(/[[:alpha:]]/)
       term_element['group-by'] = group_by
 
       # Add it to our index object

--- a/lib/kitchen/directions/bake_index/v1.rb
+++ b/lib/kitchen/directions/bake_index/v1.rb
@@ -137,7 +137,7 @@ module Kitchen::Directions::BakeIndex
 
     def add_term_to_index(term_element, page_title)
       group_by = term_element.text.strip[0]
-      group_by = I18n.t(:eob_index_symbols_group) unless group_by.match?(/\w/)
+      group_by = I18n.t(:eob_index_symbols_group) unless group_by.match?(/[a-zA-Z]/)
       term_element['group-by'] = group_by
 
       # Add it to our index object

--- a/lib/kitchen/directions/bake_index/v1.rb
+++ b/lib/kitchen/directions/bake_index/v1.rb
@@ -136,7 +136,6 @@ module Kitchen::Directions::BakeIndex
     end
 
     def add_term_to_index(term_element, page_title)
-      # group_by = term_element.text.strip[0]
       group_by = I18n.transliterate(term_element.text.strip[0])
       group_by = I18n.t(:eob_index_symbols_group) unless group_by.match?(/[[:alpha:]]/)
       term_element['group-by'] = group_by

--- a/spec/directions/bake_index/v1_spec.rb
+++ b/spec/directions/bake_index/v1_spec.rb
@@ -183,6 +183,15 @@ RSpec.describe Kitchen::Directions::BakeIndex::V1 do
     expect(a_section.items.map(&:term_text)).to eq ['3-PGA', '3-phosphoglycerate', '5’ cap', '70S ribosome']
   end
 
+  it 'groups correctly letters with accent marks' do
+    a_section.add_term(text_only_term('Ötzi the Iceman'))
+    a_section.add_term(text_only_term('éblahblah'))
+    a_section.add_term(text_only_term('Eab-ellipse'))
+    a_section.add_term(text_only_term('Ombre'))
+
+    expect(a_section.items.map(&:term_text)).to eq ['Eab-ellipse', 'éblahblah', 'Ombre', 'Ötzi the Iceman']
+  end
+
   def text_only_term(text)
     described_class::Term.new(text: text, id: nil, group_by: nil, page_title: nil)
   end

--- a/spec/directions/bake_index/v1_spec.rb
+++ b/spec/directions/bake_index/v1_spec.rb
@@ -174,6 +174,15 @@ RSpec.describe Kitchen::Directions::BakeIndex::V1 do
     expect(a_section.items.first.term_text).to eq 'temperature'
   end
 
+  it 'groups by number when word starts with a number' do
+    a_section.add_term(text_only_term('70S ribosome'))
+    a_section.add_term(text_only_term('3-PGA'))
+    a_section.add_term(text_only_term('5’ cap'))
+    a_section.add_term(text_only_term('3-phosphoglycerate'))
+
+    expect(a_section.items.map(&:term_text)).to eq ['3-PGA', '3-phosphoglycerate', '5’ cap', '70S ribosome']
+  end
+
   def text_only_term(text)
     described_class::Term.new(text: text, id: nil, group_by: nil, page_title: nil)
   end

--- a/spec/directions/bake_index/v1_spec.rb
+++ b/spec/directions/bake_index/v1_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Kitchen::Directions::BakeIndex::V1 do
           <span data-type="term">Foo</span>
           <span data-type="term">Bar</span>
           <span data-type="term">bar</span>
+          <span data-type="term">Ötzi the Iceman</span>
         </div>
         <div data-type="chapter">
           <div data-type="page" id="p2">
@@ -36,6 +37,7 @@ RSpec.describe Kitchen::Directions::BakeIndex::V1 do
             <span data-type="term">foo</span>
             <span data-type="term">ΔE</span>
             <span data-type="term"><em>sp</em><sup>3</sup><em>d</em><sup>2</sup> orbitals</span>
+            <span data-type="term">3-PGA</span>
           </div>
           <div data-type="composite-chapter">
             <div data-type="document-title">Chapter Review</div>
@@ -50,6 +52,8 @@ RSpec.describe Kitchen::Directions::BakeIndex::V1 do
           <div data-type="composite-page">
             <div data-type="document-title">Another EOC Section</div>
             <span data-type="term">composite page at the top level</span>
+            <span data-type="term">éblahblah</span>
+            <span data-type="term">5’ cap</span>
           </div>
         </div>
       HTML
@@ -76,8 +80,20 @@ RSpec.describe Kitchen::Directions::BakeIndex::V1 do
           <div class="group-by">
             <span class="group-label">Symbols</span>
             <div class="os-index-item">
+            <span class="os-term" group-by="Symbols">3-PGA</span>
+              <a class="os-term-section-link" href="#auto_p2_term9">
+                <span class="os-term-section">1.1 First Page</span>
+              </a>
+            </div>
+            <div class="os-index-item">
+              <span class="os-term" group-by="Symbols">5&#x2019; cap</span>
+              <a class="os-term-section-link" href="#auto_composite_page_term4">
+                <span class="os-term-section">2 Another EOC Section</span>
+              </a>
+            </div>
+            <div class="os-index-item">
               <span class="os-term" group-by="Symbols">&#x394;E</span>
-              <a class="os-term-section-link" href="#auto_p2_term6">
+              <a class="os-term-section-link" href="#auto_p2_term7">
                 <span class="os-term-section">1.1 First Page</span>
               </a>
             </div>
@@ -111,6 +127,15 @@ RSpec.describe Kitchen::Directions::BakeIndex::V1 do
             </div>
           </div>
           <div class="group-by">
+            <span class="group-label">E</span>
+            <div class="os-index-item">
+              <span class="os-term" group-by="e">&#xE9;blahblah</span>
+              <a class="os-term-section-link" href="#auto_composite_page_term3">
+                <span class="os-term-section">2 Another EOC Section</span>
+              </a>
+            </div>
+          </div>
+          <div class="group-by">
             <span class="group-label">F</span>
             <div class="os-index-item">
               <span class="os-term" group-by="f">foo</span>
@@ -122,8 +147,17 @@ RSpec.describe Kitchen::Directions::BakeIndex::V1 do
                 <span class="os-term-section">Preface</span>
               </a>
               <span class="os-index-link-separator">, </span>
-              <a class="os-term-section-link" href="#auto_p2_term5">
+              <a class="os-term-section-link" href="#auto_p2_term6">
                 <span class="os-term-section">1.1 First Page</span>
+              </a>
+            </div>
+          </div>
+          <div class="group-by">
+            <span class="group-label">O</span>
+            <div class="os-index-item">
+              <span class="os-term" group-by="O">&#xD6;tzi the Iceman</span>
+              <a class="os-term-section-link" href="#auto_p1_term5">
+                <span class="os-term-section">Preface</span>
               </a>
             </div>
           </div>
@@ -131,7 +165,7 @@ RSpec.describe Kitchen::Directions::BakeIndex::V1 do
             <span class="group-label">S</span>
             <div class="os-index-item">
               <span class="os-term" group-by="s">sp3d2 orbitals</span>
-              <a class="os-term-section-link" href="#auto_p2_term7">
+              <a class="os-term-section-link" href="#auto_p2_term8">
                 <span class="os-term-section">1.1 First Page</span>
               </a>
             </div>
@@ -172,24 +206,6 @@ RSpec.describe Kitchen::Directions::BakeIndex::V1 do
     a_section.add_term(text_only_term('Temperature'))
     expect(a_section.items.count).to eq 1
     expect(a_section.items.first.term_text).to eq 'temperature'
-  end
-
-  it 'groups by number when word starts with a number' do
-    a_section.add_term(text_only_term('70S ribosome'))
-    a_section.add_term(text_only_term('3-PGA'))
-    a_section.add_term(text_only_term('5’ cap'))
-    a_section.add_term(text_only_term('3-phosphoglycerate'))
-
-    expect(a_section.items.map(&:term_text)).to eq ['3-PGA', '3-phosphoglycerate', '5’ cap', '70S ribosome']
-  end
-
-  it 'groups correctly letters with accent marks' do
-    a_section.add_term(text_only_term('Ötzi the Iceman'))
-    a_section.add_term(text_only_term('éblahblah'))
-    a_section.add_term(text_only_term('Eab-ellipse'))
-    a_section.add_term(text_only_term('Ombre'))
-
-    expect(a_section.items.map(&:term_text)).to eq ['Eab-ellipse', 'éblahblah', 'Ombre', 'Ötzi the Iceman']
   end
 
   def text_only_term(text)


### PR DESCRIPTION
From easy-baked, the behavior for words like `Ötzi the Iceman` are expected to be grouped as symbols, but the currently expected behavior is for those to be grouped by letter, this PR changes fixes that issue.