### PR TITLE
Update Bake Summary to skip pages without a summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Allow `BakeChapterSummary` to skip pages where there is no summary (minor)
+* Change `PageElement#summary` to return nil instead of raise an error if no matches (major?)
+* Add `PageElement#summary!` method that raises an error if no matches (minor)
 
 * Add Rubocop and a working CHANGELOG check to GitHub actions (patch)
 * Allow `BakeFootnotes` to number footnotes with Roman numerals (minor)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Allow `BakeChapterSummary` to skip pages where there is no summary (minor)
 * Change `PageElement#summary` to return nil instead of raise an error if no matches (major?)
-* Add `PageElement#summary!` method that raises an error if no matches (minor)
 
 * Add Rubocop and a working CHANGELOG check to GitHub actions (patch)
 * Allow `BakeFootnotes` to number footnotes with Roman numerals (minor)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Allow `BakeChapterSummary` to skip pages where there is no summary (minor)
+
 * Add Rubocop and a working CHANGELOG check to GitHub actions (patch)
 * Allow `BakeFootnotes` to number footnotes with Roman numerals (minor)
 * Create V2 for `BakeNumberedTables` (minor)

--- a/lib/kitchen/directions/bake_chapter_summary.rb
+++ b/lib/kitchen/directions/bake_chapter_summary.rb
@@ -26,7 +26,11 @@ module Kitchen
 
           # TODO: include specific page types somehow without writing it out
           chapter.non_introduction_pages.each do |page|
-            summary = page.summary
+            begin
+              summary = page.summary
+            rescue
+              next
+            end
             summary.first("[data-type='title']")&.trash # get rid of old title if exists
             summary_title = page.title.copy
             summary_title.name = 'h3'

--- a/lib/kitchen/directions/bake_chapter_summary.rb
+++ b/lib/kitchen/directions/bake_chapter_summary.rb
@@ -26,11 +26,10 @@ module Kitchen
 
           # TODO: include specific page types somehow without writing it out
           chapter.non_introduction_pages.each do |page|
-            begin
-              summary = page.summary
-            rescue
-              next
-            end
+            summary = page.summary
+
+            next if summary.nil?
+
             summary.first("[data-type='title']")&.trash # get rid of old title if exists
             summary_title = page.title.copy
             summary_title.name = 'h3'

--- a/lib/kitchen/page_element.rb
+++ b/lib/kitchen/page_element.rb
@@ -88,10 +88,18 @@ module Kitchen
 
     # Returns the summary element.
     #
+    # @return [Element, nil] the summary or nil if no summary found
+    #
+    def summary
+      first(selectors.page_summary)
+    end
+
+    # Returns the summary element.
+    #
     # @raise [ElementNotFoundError] if no matching element is found
     # @return [Element]
     #
-    def summary
+    def summary!
       first!(selectors.page_summary)
     end
 

--- a/lib/kitchen/page_element.rb
+++ b/lib/kitchen/page_element.rb
@@ -94,15 +94,6 @@ module Kitchen
       first(selectors.page_summary)
     end
 
-    # Returns the summary element.
-    #
-    # @raise [ElementNotFoundError] if no matching element is found
-    # @return [Element]
-    #
-    def summary!
-      first!(selectors.page_summary)
-    end
-
     # Returns the exercises element.
     #
     # @raise [ElementNotFoundError] if no matching element is found


### PR DESCRIPTION
catches a 'no summary on page' error and moves to the next page. (had a chat with Larissa, said yes)