### PR TITLE
BakeNumberedNotes Bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Allow `BakeChapterSummary` to skip pages where there is no summary (minor)
 * Change `PageElement#summary` to return nil instead of raise an error if no matches (major?)
+* Fix bug in `BakeNumberedNotes:::V3` when there are multiple os-numbers (minor)
 
 * Add Rubocop and a working CHANGELOG check to GitHub actions (patch)
 * Allow `BakeFootnotes` to number footnotes with Roman numerals (minor)

--- a/lib/kitchen/directions/bake_notes/bake_numbered_notes/v3.rb
+++ b/lib/kitchen/directions/bake_notes/bake_numbered_notes/v3.rb
@@ -8,7 +8,7 @@ module Kitchen::Directions::BakeNumberedNotes
         book.chapters.notes("$.#{klass}").each do |note|
           note.wrap_children(class: 'os-note-body')
           previous_example = note.previous
-          os_number = previous_example&.content('.os-number')
+          os_number = previous_example&.first('.os-number')&.children&.to_s
 
           note.prepend(child:
             <<~HTML

--- a/spec/directions/bake_notes/bake_numbered_notes/v3_spec.rb
+++ b/spec/directions/bake_notes/bake_numbered_notes/v3_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe Kitchen::Directions::BakeNumberedNotes::V3 do
           </div>
           <div data-type="exercise">
             <span class="os-number">1.4</span>
+            <figure>
+              <span class="os-title">Figure</span>
+              <span class="os-number">1.1</span>
+            </figure>
           </div>
           <div data-type="note" id="222" class="hello">
             <p>content 1.4</p>
@@ -128,6 +132,10 @@ RSpec.describe Kitchen::Directions::BakeNumberedNotes::V3 do
             </div>
             <div data-type="exercise">
               <span class="os-number">1.4</span>
+              <figure>
+                <span class="os-title">Figure</span>
+                <span class="os-number">1.1</span>
+              </figure>
             </div>
             <div class="hello" data-type="note" id="222">
               <h3 class="os-title">


### PR DESCRIPTION
Fixes a os-number bug for when the previous example has two os-numbers (say, the exercise number it was _supposed_ to inherit **and** the os-number of a figure inside the exercise)