### PR TITLE
add cache_methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add `cache_methods` method to Element classes to enable opt-in caching of queries (minor)
+
 ## [6.1.0] - 2021-06-17
 
 * Create a `BakeReferences` V2 for unnumbered section references (minor)

--- a/README.md
+++ b/README.md
@@ -657,6 +657,15 @@ There's a low-level CSS query caching tool that saves repeated queries.  In some
 doc.config.enable_search_cache = true
 ```
 
+You can also selectively cache certain methods for elements that don't move around.  For example, at the top of your recipe you can say:
+
+```ruby
+Kitchen::BookElement.cache_methods(:metadata, :chapters)
+Kitchen::PageElement.cache_methods(:pages, :non_introduction_pages)
+```
+
+This _should_ be fine to do, but make sure to check your profile stats and baking times with and without this (along with checking that your recipe output looks good).
+
 ### VSCode
 
 1. Visit `vscode:extension/ms-vscode-remote.remote-containers` in a browser

--- a/lib/kitchen/element_base.rb
+++ b/lib/kitchen/element_base.rb
@@ -11,6 +11,7 @@ module Kitchen
   class ElementBase
     extend Forwardable
     include Mixins::BlockErrorIf
+    include Mixins::CacheMethods
 
     # The element's document
     # @return [Document]

--- a/lib/kitchen/mixins/cache_methods.rb
+++ b/lib/kitchen/mixins/cache_methods.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# rubocop:disable Style/Documentation
+module Kitchen
+  module Mixins
+    # A mixin for including the cache_methods class method
+    #
+    # @example
+    #   class Kitchen::BookElement
+    #     include Mixins::CacheMethods
+    #   end
+    #
+    #   class SomeRecipe
+    #     Kitchen::BookElement.cache_methods(:metadata, :chapters)
+    #     ...
+    #     # now when you call `book.chapters` the result will be cached for subsequent calls
+    #   end
+    #
+    module CacheMethods
+      module ClassMethods
+        # Caches the results for the given methods such that subsequent calls with the same
+        # arguments on the same object return the cached result instead of repeating the
+        # (likely expensive) original call.
+        #
+        # Should only call this for methods which don't in fact change their result during
+        # baking.  E.g. chapters and pages pretty much stay in the same place even if their
+        # internal nodes change, so they are decent candidates.
+        #
+        # After calling cache_methods, the original implementation of the given methods will still
+        # available as `uncached_#{method}`, e.g. when calling `cache_methods(:foo, :bar)`,
+        # `uncached_foo` and `uncached_bar` are available.
+        #
+        # @param methods [Array<String, Symbol] a list of methods to cache
+        #
+        def cache_methods(*methods)
+          methods.each do |method|
+            method = method.to_sym
+            uncached_method = "uncached_#{method}".to_sym
+
+            alias_method uncached_method, method
+
+            define_method(method) do |*args, &block|
+              @cached_method_results ||= {}
+
+              cache_key = [method, args]
+              cache_key.push(block.source_location[0]) if block_given?
+
+              @cached_method_results[cache_key] ||= send(uncached_method, *args, &block)
+            end
+          end
+        end
+      end
+
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
+    end
+  end
+end
+# rubocop:enable Style/Documentation

--- a/spec/mixins/cache_methods_spec.rb
+++ b/spec/mixins/cache_methods_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe Kitchen::Mixins::CacheMethods do
+  before do
+    stub_const('CacheMethodsTestClass', Class.new do
+      include Kitchen::Mixins::CacheMethods
+      def some_method(_foo)
+        Random.rand
+      end
+    end)
+
+    CacheMethodsTestClass.cache_methods(:some_method)
+  end
+
+  it 'caches the result of some_method' do
+    instance = CacheMethodsTestClass.new
+    first_call_blah = instance.some_method('blah')
+    expect(instance.some_method('blah')).to eq first_call_blah
+    expect(instance.some_method('foobar')).not_to eq first_call_blah
+  end
+
+  it 'provides a way to get the uncached method' do
+    instance = CacheMethodsTestClass.new
+    first_call_blah = instance.some_method('blah')
+    expect(instance.uncached_some_method('blah')).not_to eq first_call_blah
+  end
+end


### PR DESCRIPTION
You know how we are manually caching things in recipes with lines like `metadata = book.metadata`?  This PR gives a way to do that for more methods more easily.  E.g. you can say

```ruby
Kitchen::BookElement.cache_methods(:metadata, :chapters)
Kitchen::PageElement.cache_methods(:pages, :non_introduction_pages)
```

at the top of your recipe and this PR will cache the results from calls like `book.chapters` and then for each chapter the subsequent calls to `chapter.pages`.  This caching is only recommended for search results that don't change (obviously) -- i.e. chapters don't really move around in our baking, so it _should_ be ok to use this.  Definitely check the results and check the profiling time changes!