### PR TITLE
Toc composite page references selector fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Fix Rubocop GitHub Action's regular expression used to select files to lint (patch)
+* Fix selector for section `References` (with class `.references`) which are children of chapter/composite-chapter in `BakeToc` (major)
 
 ## [6.1.0] - 2021-06-21
 
@@ -40,10 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Adds `BakeNumberedNotes` V3 (minor)
 * Added line that puts the classname `has-footnote` in the footnote ref's parent element (major)
 * Added a condition into `BakeChapterSummary` so it doesn't bake the title if it already includes the respective number in it
-* Create v3 of MoveExercisesToEOC which differs from v1 by the presence of a section title
-and from v2 the lack of additional "os-section-area" and os-#{@klass} wrapper (minor)
-* Add a condition in BakeNumberedExercise to make it possible to suppress even solutions in the Answer Key (minor)
-* Fix BakeFurtherResearch baking with main bake script error by breaking the loop if further research sections are not present (minor)
+* Create v3 of `MoveExercisesToEOC` which differs from v1 by the presence of a section title
+and from v2 the lack of additional `os-section-area` and `os-#{@klass} wrapper` (minor)
+* Add a condition in `BakeNumberedExercise` to make it possible to suppress even solutions in the Answer Key (minor)
+* Fix `BakeFurtherResearch` baking with main bake script error by breaking the loop if further research sections are not present (minor)
 * Rework v1 of `BakeChapterReferences` to bake references also from introduction pages (major)
 * Fix for `BakeIndex` for words that start with a number to be grouped as symbols and for first letters with accent marks to be grouped with regular letters in alphabetic order (major)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Fix Rubocop GitHub Action's regular expression used to select files to lint (patch)
-* Fix selector for section `References` (with class `.references`) which are children of chapter/composite-chapter in `BakeToc` (major)
-
+* Add more specific book part selector (`os-eob`) for References in `is_citation_reference?`, `is_section_reference?` methods in Element Base to fix toc selector for References which are moved to EoC.
 ## [6.1.0] - 2021-06-21
 
 * Create a `BakeReferences` V2 for unnumbered section references (minor)

--- a/lib/kitchen/composite_page_element.rb
+++ b/lib/kitchen/composite_page_element.rb
@@ -57,7 +57,7 @@ module Kitchen
     # @return [Boolean]
     #
     def is_citation_reference?
-      has_class?('os-reference-container')
+      has_class?('os-eob os-reference-container')
     end
 
     # Returns true if this page is a book section reference
@@ -65,7 +65,7 @@ module Kitchen
     # @return [Boolean]
     #
     def is_section_reference?
-      has_class?('os-references-container')
+      has_class?('os-eob os-references-container')
     end
 
   end

--- a/lib/kitchen/directions/bake_toc.rb
+++ b/lib/kitchen/directions/bake_toc.rb
@@ -99,7 +99,7 @@ module Kitchen
             elsif page.is_citation_reference?
               'os-toc-reference'
             elsif page.is_section_reference? && !page.has_ancestor?(:composite_chapter) && !page.has_ancestor?(:chapter)
-              'os-toc-references'
+              'os-toc-chapter-composite-page'
             elsif page.has_ancestor?(:composite_chapter) || page.has_ancestor?(:chapter)
               'os-toc-chapter-composite-page'
             else

--- a/lib/kitchen/directions/bake_toc.rb
+++ b/lib/kitchen/directions/bake_toc.rb
@@ -98,7 +98,7 @@ module Kitchen
               'os-toc-index'
             elsif page.is_citation_reference?
               'os-toc-reference'
-            elsif page.is_section_reference?
+            elsif page.is_section_reference? && !page.has_ancestor?(:composite_chapter) && !page.has_ancestor?(:chapter)
               'os-toc-references'
             elsif page.has_ancestor?(:composite_chapter) || page.has_ancestor?(:chapter)
               'os-toc-chapter-composite-page'

--- a/lib/kitchen/directions/bake_toc.rb
+++ b/lib/kitchen/directions/bake_toc.rb
@@ -98,8 +98,8 @@ module Kitchen
               'os-toc-index'
             elsif page.is_citation_reference?
               'os-toc-reference'
-            elsif page.is_section_reference? && !page.has_ancestor?(:composite_chapter) && !page.has_ancestor?(:chapter)
-              'os-toc-chapter-composite-page'
+            elsif page.is_section_reference?
+              'os-toc-references'
             elsif page.has_ancestor?(:composite_chapter) || page.has_ancestor?(:chapter)
               'os-toc-chapter-composite-page'
             else

--- a/spec/directions/bake_toc_spec.rb
+++ b/spec/directions/bake_toc_spec.rb
@@ -102,12 +102,12 @@ RSpec.describe Kitchen::Directions::BakeToc do
                 <span data-type="" itemprop="" class="os-text">Page 3.1 Title</span>
               </h2>
             </div>
-            <div data-type="composite-page" id="composite-page-2">
+            <div data-type="composite-page" id="composite-page-3">
               <h2 data-type="document-title">
                 <span class="os-text">Key Terms</span>
               </h2>
             </div>
-            <div class = "os-eoc os-references-container" data-type="composite-page" id="composite-page-3">
+            <div class = "os-eoc os-references-container" data-type="composite-page" id="composite-page-4">
               <h2 data-type="document-title">
                 <span class="os-text">References</span>
               </h2>
@@ -402,13 +402,13 @@ RSpec.describe Kitchen::Directions::BakeToc do
                         <span class="os-text" data-type="" itemprop="">Page 3.1 Title</span>
                       </a>
                     </li>
-                    <li class="os-toc-chapter-composite-page" cnx-archive-shortid="" cnx-archive-uri="composite-page-2">
-                      <a href="#composite-page-2">
+                    <li class="os-toc-chapter-composite-page" cnx-archive-shortid="" cnx-archive-uri="composite-page-3">
+                      <a href="#composite-page-3">
                         <span class="os-text">Key Terms</span>
                       </a>
                     </li>
-                    <li class="os-toc-chapter-composite-page" cnx-archive-shortid="" cnx-archive-uri="composite-page-3">
-                      <a href="#composite-page-3">
+                    <li class="os-toc-chapter-composite-page" cnx-archive-shortid="" cnx-archive-uri="composite-page-4">
+                      <a href="#composite-page-4">
                         <span class="os-text">References</span>
                       </a>
                     </li>

--- a/spec/directions/bake_toc_spec.rb
+++ b/spec/directions/bake_toc_spec.rb
@@ -55,6 +55,11 @@ RSpec.describe Kitchen::Directions::BakeToc do
                 <span class="os-text">Key Terms</span>
               </h2>
             </div>
+            <div class="os-eoc os-references-container" data-type="composite-page" id="composite-page-2">
+              <h2 data-type="document-title">
+                <span class="os-text">References</span>
+              </h2>
+            </div>
           </div>
           <div data-type="chapter">
             <h1 data-type="document-title" id="chapTitle2">
@@ -102,6 +107,11 @@ RSpec.describe Kitchen::Directions::BakeToc do
                 <span class="os-text">Key Terms</span>
               </h2>
             </div>
+            <div class = "os-eoc os-references-container" data-type="composite-page" id="composite-page-3">
+              <h2 data-type="document-title">
+                <span class="os-text">References</span>
+              </h2>
+            </div>
           </div>
         </div>
         <div data-type="page" id="p7" class="appendix">
@@ -122,12 +132,12 @@ RSpec.describe Kitchen::Directions::BakeToc do
             </h2>
           </div>
         </div>
-        <div class="os-reference-container" data-type="composite-page" id="p9"> # citation type
+        <div class="os-eob os-reference-container" data-type="composite-page" id="p9"> # citation type
           <h1 data-type="document-title">
             <span class="os-text">References</span>
           </h1>
         </div>
-        <div class="os-references-container" data-type="composite-page" id="p10"> # section type
+        <div class="os-eob os-references-container" data-type="composite-page" id="p10"> # section type
           <h1 data-type="document-title">
             <span class="os-text">References</span>
           </h1>
@@ -181,6 +191,11 @@ RSpec.describe Kitchen::Directions::BakeToc do
                 <span class="os-text">Key Terms</span>
               </h2>
             </div>
+            <div class = "os-eoc os-references-container" data-type="composite-page" id="composite-page-2">
+              <h2 data-type="document-title">
+                <span class="os-text">References</span>
+              </h2>
+            </div>
           </div>
           <div data-type="chapter">
             <h1 data-type="document-title" id="chapTitle2">
@@ -215,12 +230,12 @@ RSpec.describe Kitchen::Directions::BakeToc do
             </h2>
           </div>
         </div>
-        <div class="os-reference-container" data-type="composite-page" id="p7"> # citation type
+        <div class="os-eob os-reference-container" data-type="composite-page" id="p7"> # citation type
           <h1 data-type="document-title">
             <span class="os-text">References</span>
           </h1>
         </div>
-        <div class="os-references-container" data-type="composite-page" id="p8"> # section type
+        <div class="os-eob os-references-container" data-type="composite-page" id="p8"> # section type
           <h1 data-type="document-title">
             <span class="os-text">References</span>
           </h1>
@@ -336,6 +351,11 @@ RSpec.describe Kitchen::Directions::BakeToc do
                         <span class="os-text">Key Terms</span>
                       </a>
                     </li>
+                    <li class="os-toc-chapter-composite-page" cnx-archive-shortid="" cnx-archive-uri="composite-page-2">
+                      <a href="#composite-page-2">
+                        <span class="os-text">References</span>
+                      </a>
+                    </li>
                   </ol>
                 </li>
                 <li class="os-toc-chapter" cnx-archive-shortid="" cnx-archive-uri="">
@@ -385,6 +405,11 @@ RSpec.describe Kitchen::Directions::BakeToc do
                     <li class="os-toc-chapter-composite-page" cnx-archive-shortid="" cnx-archive-uri="composite-page-2">
                       <a href="#composite-page-2">
                         <span class="os-text">Key Terms</span>
+                      </a>
+                    </li>
+                    <li class="os-toc-chapter-composite-page" cnx-archive-shortid="" cnx-archive-uri="composite-page-3">
+                      <a href="#composite-page-3">
+                        <span class="os-text">References</span>
                       </a>
                     </li>
                   </ol>
@@ -467,6 +492,11 @@ RSpec.describe Kitchen::Directions::BakeToc do
                   <a href="#composite-page-1">
                     <span class="os-text">Key Terms</span>
                   </a>
+                </li>
+                <li class="os-toc-chapter-composite-page" cnx-archive-shortid="" cnx-archive-uri="composite-page-2">
+                      <a href="#composite-page-2">
+                        <span class="os-text">References</span>
+                      </a>
                 </li>
               </ol>
             </li>


### PR DESCRIPTION
This PR fixes toc class for `.references`. I have noticed that after recent changes the selector has changed there in Sociology: 
![image](https://user-images.githubusercontent.com/55203598/122800283-09373200-d2c3-11eb-8735-d8d18a8868e9.png)
