### PR TITLE
keep node connections during wrap_children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Sort terms in `BakeChapterGlossary` in language specific way (major)
 * Spanish translation change (minor)
-* Added a check to bake nested notes inside `BakeAutotitledNotes` (minor)
+* Fixed the implementation of `Element#wrap_children` to reuse existing document elements (major).
 
 ## [7.0.0] - 2021-06-21
 

--- a/lib/kitchen/directions/bake_notes/bake_autotitled_notes.rb
+++ b/lib/kitchen/directions/bake_notes/bake_autotitled_notes.rb
@@ -4,10 +4,10 @@ module Kitchen
   module Directions
     module BakeAutotitledNotes
       def self.v1(book:, classes:)
-        classes.each do |klass|
-          book.notes("$.#{klass}").each do |note|
-            bake_note(note: note)
-          end
+        book.notes.each do |note|
+          next unless (note.classes & classes).any?
+
+          bake_note(note: note)
         end
       end
 

--- a/lib/kitchen/element_base.rb
+++ b/lib/kitchen/element_base.rb
@@ -602,9 +602,9 @@ module Kitchen
         attributes.each do |k, v|
           new_node[k.to_s.gsub(/([^_])_([^_])/, '\1-\2').gsub('__', '_')] = v
         end
-        new_node.children = children.to_s
+        new_node.children = children
         yield Element.new(node: new_node, document: document, short_type: nil) if block_given?
-      end.to_s
+      end
 
       self
     end

--- a/spec/element_base_spec.rb
+++ b/spec/element_base_spec.rb
@@ -390,6 +390,22 @@ RSpec.describe Kitchen::ElementBase do
         '<div><div data_type="foo">something <i>awesome</i></div></div>'
       )
     end
+
+    context 'when a search finds nested elements and we use wrap_children' do
+      let(:element) { new_element('<outer><div class="bar">something <div class="bar">internal</div></div></outer>') }
+
+      it 'maintains the document structure so that iteration to nested elements still works' do
+        element.search('div.bar').each do |match|
+          match.add_class('foo')
+          match.wrap_children('div')
+        end
+
+        expect(element).to match_normalized_html(
+          '<outer><div class="bar foo"><div>something <div class="bar foo"><div>internal</div></div></div></div></outer>'
+        )
+      end
+
+    end
   end
 
   describe '#content' do


### PR DESCRIPTION
Changes the implementation of `Element#wrap_children` to keep the original child elements from the document.  The prior implementation converted child elements to strings, which meant the original elements were lost.  This was a problem when a search result had already found child elements (e.g. in the case of nested notes and a "notes" search), because the found child elements were replaced with new elements (during a `to_s` conversion) and when the replaced results were processed during subsequent baking those changes had no effect (as those child elements had been removed from the book structure by a prior baking step).