### PR TITLE
Fix nested examples double-baking exercises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Fix `BakeExample` to skip baked exercises (patch)
 * Add `FigureElement#figure_to_bake?` (minor)
 * Remove `itemprop` attribute from `BakeChapterSummary` and `BakeFurtherResearch` (major)
 * Fix `NoteElement#title` to exclude nested element titles (patch)

--- a/lib/kitchen/directions/bake_example.rb
+++ b/lib/kitchen/directions/bake_example.rb
@@ -31,6 +31,8 @@ module Kitchen
         end
 
         example.exercises.each do |exercise|
+          next if exercise.baked?
+
           if (problem = exercise.problem)
             problem.titles.each { |title| title.name = 'h4' }
             problem.wrap_children(class: 'os-problem-container')

--- a/lib/kitchen/exercise_element.rb
+++ b/lib/kitchen/exercise_element.rb
@@ -39,6 +39,10 @@ module Kitchen
       first("div[data-type='solution']")
     end
 
+    # Returns whether the exercise has been baked
+    #
+    # @return [Boolean]
+    #
     def baked?
       search('div.os-problem-container').any?
     end

--- a/lib/kitchen/exercise_element.rb
+++ b/lib/kitchen/exercise_element.rb
@@ -38,5 +38,9 @@ module Kitchen
     def solution
       first("div[data-type='solution']")
     end
+
+    def baked?
+      search('div.os-problem-container').any?
+    end
   end
 end


### PR DESCRIPTION
Detects whether an exercise in an example has been baked & skips baking again if so