### PR TITLE
Add `ExampleElement#titles_to_rename` & refactor `BakeExample`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+* Add `ExampleElement#titles_to_rename` & refactor `BakeExample` (patch)
 * Create `BakeUnitPageTitle` (minor)
 * Fix `BakeExample` to skip baked exercises (patch)
 * Add `FigureElement#figure_to_bake?` (minor)

--- a/lib/kitchen/directions/bake_example.rb
+++ b/lib/kitchen/directions/bake_example.rb
@@ -20,13 +20,7 @@ module Kitchen
                .pantry(name: :link_text)
                .store("#{I18n.t(:example_label)} #{number}", label: example.id)
 
-        example.titles.each do |title|
-          if title.parent.has_class?('os-caption-container') || \
-             title.parent.has_class?('os-caption') || \
-             title.parent.name == 'caption'
-            next
-          end
-
+        example.titles_to_rename.each do |title|
           title.name = 'h4'
         end
 
@@ -34,7 +28,6 @@ module Kitchen
           next if exercise.baked?
 
           if (problem = exercise.problem)
-            problem.titles.each { |title| title.name = 'h4' }
             problem.wrap_children(class: 'os-problem-container')
           end
 

--- a/lib/kitchen/example_element.rb
+++ b/lib/kitchen/example_element.rb
@@ -27,9 +27,15 @@ module Kitchen
     #
     # @return [ElementEnumerator]
     #
-    def titles
-      search("[data-type='title']")
+    def titles_to_rename
+      titles(except: \
+        lambda do |title|
+          title.parent.has_class?('os-caption-container') || \
+          title.parent.has_class?('os-caption') || \
+          title.parent.name == 'caption' || \
+          title.parent[:'data-type'] == 'note'
+        end
+      )
     end
-
   end
 end

--- a/spec/directions/bake_example_spec.rb
+++ b/spec/directions/bake_example_spec.rb
@@ -384,4 +384,49 @@ RSpec.describe Kitchen::Directions::BakeExample do
       example.pantry(name: :link_text).get(example.id)
     }.from(nil)
   end
+
+  describe 'ExampleElement#titles_to_rename' do
+    let(:example) do
+      book_containing(html:
+        <<~HTML
+          <div data-type="chapter">
+            <div data-type="page">
+              <div data-type="document-title" id="auto_m68761_72010">Page 1 Title</div>
+              <div data-type='example' id='example-test'>
+                <span data-type="title" id="title1">example title becomes h4</span>
+                <div data-type="exercise">
+                  <span data-type="title" id="title2">exercises title becomes h4(?)</span>
+                </div>
+                <div data-type="note">
+                  <h3 data-type="title" id="title3">note title is skipped</h3>
+                </div>
+                <table><caption><span data-type="title" id="title4">unbaked table title is skipped</span></caption></table>
+                <div class="os-table">
+                  <table></table>
+                  <div class="os-caption-container">
+                    <span data-type="title" id="title5">baked table title (V1) is skipped</span>
+                  </div>
+                </div>
+                <div class="os-table">
+                  <table></table>
+                  <div class="os-caption-container">
+                    <div class="os-caption">
+                      <span data-type="title" id="title6">baked table title (V2) is skipped</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        HTML
+      ).examples.first
+    end
+
+    it 'skips titles within tables & notes' do
+      ids = %w[title1 title2]
+      example.titles_to_rename.each_with_index do |title, index|
+        expect(title.id).to eq(ids[index])
+      end
+    end
+  end
 end


### PR DESCRIPTION
`BakeExample` has been a problem because it targets titles to convert them to `h4`s, but examples can contain nested elements such as exercises, tables, and notes that shouldn't have their titles affected (except in the case of exercises? sometimes?). This approach would allow us to select `titles_to_rename` in an example & currently has a blacklist implementation. In the future, if other types of titles need to be skipped by BakeExample, this blacklist can be updated. We might find at some point that a whitelist implementation is better than a blacklist; in that case, the implementation can be changed.