### PR TITLE
Patch BakeExample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Patch `BakeExample` crashing if an example has commentary but no title (patch)
+
 ## [10.0.0] - 2021-07-30
 
 * Add support for baking multipart questions to `BakeNumberedExercise` (minor)

--- a/lib/kitchen/directions/bake_example.rb
+++ b/lib/kitchen/directions/bake_example.rb
@@ -54,6 +54,8 @@ module Kitchen
           next unless commentary.present?
 
           commentary_title = commentary.titles.first
+          next unless commentary_title.present?
+
           commentary_title.name = 'h4'
           commentary_title['data-type'] = 'commentary-title'
           commentary_title.wrap_children('span', class: 'os-title-label')


### PR DESCRIPTION
Patches BakeExample crashing if an example has commentary but no commentary title.