### PR TITLE
Non-introduction page count method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Patch `BakeExample` crashing if an example has commentary but no title (patch)
 * Refactor `EocSectionTitleLinkSnippet` to only have v1 with optional params (major)
+* Adds `PageElement#count_in_chapter_without_intro_page` (minor)
+* Adds `ChapterElement#has_introduction?` (minor)
 
 ## [10.0.0] - 2021-07-30
 

--- a/lib/kitchen/chapter_element.rb
+++ b/lib/kitchen/chapter_element.rb
@@ -44,6 +44,14 @@ module Kitchen
       pages('$.introduction').first
     end
 
+    # Returns true if the chapter has an introduction
+    #
+    # @return [Boolean]
+    #
+    def has_introduction?
+      introduction_page.present?
+    end
+
     # Returns an enumerator for the glossaries
     #
     # @return [ElementEnumerator]

--- a/lib/kitchen/chapter_element.rb
+++ b/lib/kitchen/chapter_element.rb
@@ -49,7 +49,7 @@ module Kitchen
     # @return [Boolean]
     #
     def has_introduction?
-      introduction_page.present?
+      @has_introduction ||= introduction_page.present?
     end
 
     # Returns an enumerator for the glossaries

--- a/lib/kitchen/page_element.rb
+++ b/lib/kitchen/page_element.rb
@@ -58,7 +58,7 @@ module Kitchen
     # @return [Boolean]
     #
     def is_introduction?
-      has_class?('introduction')
+      @is_introduction ||= has_class?('introduction')
     end
 
     # Returns  replaces generic call to page.count_in(:chapter)

--- a/lib/kitchen/page_element.rb
+++ b/lib/kitchen/page_element.rb
@@ -66,7 +66,7 @@ module Kitchen
     # return [Integer]
     #
     def count_in_chapter_without_intro_page
-      count_in(:chapter) - ( ancestor(:chapter).has_introduction? ? 1 : 0 )
+      count_in(:chapter) - (ancestor(:chapter).has_introduction? ? 1 : 0)
     end
 
     # Returns true if this page is a preface

--- a/lib/kitchen/page_element.rb
+++ b/lib/kitchen/page_element.rb
@@ -61,6 +61,14 @@ module Kitchen
       has_class?('introduction')
     end
 
+    # Returns  replaces generic call to page.count_in(:chapter)
+    #
+    # return [Integer]
+    #
+    def count_in_chapter_without_intro_page
+      count_in(:chapter) - ( ancestor(:chapter).has_introduction? ? 1 : 0 )
+    end
+
     # Returns true if this page is a preface
     #
     # @return [Boolean]

--- a/lib/kitchen/page_element.rb
+++ b/lib/kitchen/page_element.rb
@@ -63,9 +63,12 @@ module Kitchen
 
     # Returns  replaces generic call to page.count_in(:chapter)
     #
-    # return [Integer]
+    # @raise [StandardError] if called on an introduction page
+    # @return [Integer]
     #
     def count_in_chapter_without_intro_page
+      raise 'Introduction pages cannot be counted with this method' if is_introduction?
+
       count_in(:chapter) - (ancestor(:chapter).has_introduction? ? 1 : 0)
     end
 

--- a/spec/chapter_element_spec.rb
+++ b/spec/chapter_element_spec.rb
@@ -33,4 +33,15 @@ RSpec.describe Kitchen::ChapterElement do
       expect(sample_chapter.abstracts.first).to match_normalized_html('<div data-type="abstract">abstract 1</div>')
     end
   end
+
+  describe '#has_introduction?' do
+    it 'returns true if chapter has introduction page' do
+      expect(sample_chapter.has_introduction?).to eq(true)
+    end
+
+    it 'returns false if chapter does not have an introduction page' do
+      sample_chapter.introduction_page.trash
+      expect(sample_chapter.has_introduction?).to eq(false)
+    end
+  end
 end

--- a/spec/page_element_spec.rb
+++ b/spec/page_element_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Kitchen::PageElement do
   describe '#count_in_chapter_without_intro_page' do
     context 'with an intro page' do
       it 'breaks when asked to count an introduction page' do
-        expect { sample_chapter.introduction_page.count_in_chapter_without_intro_page }.to raise_error('Introduction pages cannot be counted with this method')
+        expect{ sample_chapter.introduction_page.count_in_chapter_without_intro_page }.to raise_error('Introduction pages cannot be counted with this method')
       end
 
       it 'numbers each page correctly' do

--- a/spec/page_element_spec.rb
+++ b/spec/page_element_spec.rb
@@ -100,19 +100,23 @@ RSpec.describe Kitchen::PageElement do
   end
 
   describe '#count_in_chapter_without_intro_page' do
+    context 'with an intro page' do
+      it 'breaks when asked to count an introduction page' do
+        expect{ sample_chapter.introduction_page.count_in_chapter_without_intro_page }.to raise_error('Introduction pages cannot be counted with this method')
+      end
+
+      it 'numbers each page correctly' do
+        count = sample_chapter.pages.map { |page| page.count_in_chapter_without_intro_page unless page.is_introduction? }
+        expect(count).to eq([nil, 1, 2])
+      end
+    end
+
     context 'with no intro page' do
       let(:introduction_page) { '' }
 
       it 'numbers each page correctly' do
         count = sample_chapter.pages.map { |page| page.count_in_chapter_without_intro_page }
         expect(count).to eq([1, 2])
-      end
-    end
-
-    context 'with an intro page' do
-      it 'numbers each page correctly' do
-        count = sample_chapter.pages.map { |page| page.count_in_chapter_without_intro_page }
-        expect(count).to eq([0, 1, 2])
       end
     end
   end

--- a/spec/page_element_spec.rb
+++ b/spec/page_element_spec.rb
@@ -58,6 +58,31 @@ RSpec.describe Kitchen::PageElement do
       )).pages.first
   end
 
+  let(:introduction_page) do
+    <<~HTML
+      <div class="introduction" data-type="page">
+        <span>stuff</span>
+      </div>
+    HTML
+  end
+
+  let(:sample_chapter) do
+    book_containing(html:
+      <<~HTML
+        <div data-type="chapter">
+          <h1 data-type="document-title">Chapter 1 Title</h1>
+          #{introduction_page}
+          <div data-type="page" class="foo">
+            <div data-type="document-title">section 1</div>
+          </div>
+          <div data-type="page" class="foo">
+            <div data-type="document-title">section 2</div>
+          </div>
+        </div>
+      HTML
+    ).chapters.first
+  end
+
   describe '#title' do
     context 'with no metadata' do
       let(:metadata) { '' }
@@ -70,6 +95,24 @@ RSpec.describe Kitchen::PageElement do
     context 'with metadata' do
       it 'finds the title' do
         expect(page1.title.text).to eq page_title_text
+      end
+    end
+  end
+
+  describe '#count_in_chapter_without_intro_page' do
+    context 'with no intro page' do
+      let(:introduction_page) {''}
+
+      it 'numbers each page correctly' do
+        count = sample_chapter.pages.map { |page| page.count_in_chapter_without_intro_page }
+        expect(count).to eq([1, 2])
+      end
+    end
+
+    context 'with an intro page' do
+      it 'numbers each page correctly' do
+        count = sample_chapter.pages.map { |page| page.count_in_chapter_without_intro_page }
+        expect(count).to eq([0, 1, 2])
       end
     end
   end

--- a/spec/page_element_spec.rb
+++ b/spec/page_element_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Kitchen::PageElement do
   describe '#count_in_chapter_without_intro_page' do
     context 'with an intro page' do
       it 'breaks when asked to count an introduction page' do
-        expect{ sample_chapter.introduction_page.count_in_chapter_without_intro_page }.to raise_error('Introduction pages cannot be counted with this method')
+        expect { sample_chapter.introduction_page.count_in_chapter_without_intro_page }.to raise_error('Introduction pages cannot be counted with this method')
       end
 
       it 'numbers each page correctly' do

--- a/spec/page_element_spec.rb
+++ b/spec/page_element_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Kitchen::PageElement do
 
   describe '#count_in_chapter_without_intro_page' do
     context 'with no intro page' do
-      let(:introduction_page) {''}
+      let(:introduction_page) { '' }
 
       it 'numbers each page correctly' do
         count = sample_chapter.pages.map { |page| page.count_in_chapter_without_intro_page }


### PR DESCRIPTION
Adds PageElement#count_in_chapter_without_intro_page and ChapterElement#has_introduction?

To better number pages when removed from their context