### PR TITLE
Fix BakeUnitPageTitle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Fix `BakeUnitPageTite` to utilize only pages which are direct children of the unit (patch)
 * Update `BakeFirstElement` to optionally add the `has-first-inline-element` class (patch)
 * Patch `BakeExample` crashing if an example has commentary but no title (patch)
 * Refactor `EocSectionTitleLinkSnippet` to only have v1 with optional params (major)

--- a/lib/kitchen/directions/bake_unit_page_title/v1.rb
+++ b/lib/kitchen/directions/bake_unit_page_title/v1.rb
@@ -3,8 +3,10 @@
 module Kitchen::Directions::BakeUnitPageTitle
   class V1
     def bake(book:)
-      book.units.pages.each do |page|
-        compose_unit_page_title(page: page)
+      book.units.each do |unit|
+        unit.element_children.only(Kitchen::PageElement).each do |page|
+          compose_unit_page_title(page: page)
+        end
       end
     end
 


### PR DESCRIPTION
Issue: #347
It narrows searching the unit pages to unit direct children only.