### PR TITLE
create bake iframes general directory

### DIFF
--- a/lib/kitchen/directions/bake_iframe/main.rb
+++ b/lib/kitchen/directions/bake_iframe/main.rb
@@ -1,0 +1,9 @@
+module Kitchen
+  module Directions
+    module BakeIframes
+      def self.v1(outer_element:)
+        V1.new.bake(outer_element: outer_element)
+      end
+    end
+  end
+end

--- a/lib/kitchen/directions/bake_iframe/v1.rb
+++ b/lib/kitchen/directions/bake_iframe/v1.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
-module Kitchen
-  module Directions
-    module BakeNoteIFrames
-      def self.v1(note:)
-        iframes = note.search('iframe')
+module Kitchen::Directions::BakeIframes
+  class V1
+      def bake(outer_element:)
+        iframes = outer_element.search('iframe')
         return unless iframes.any?
 
         iframes.each do |iframe|
@@ -22,6 +21,5 @@ module Kitchen
           )
         end
       end
-    end
   end
 end

--- a/lib/kitchen/directions/bake_notes/bake_autotitled_notes.rb
+++ b/lib/kitchen/directions/bake_notes/bake_autotitled_notes.rb
@@ -12,7 +12,7 @@ module Kitchen
       end
 
       def self.bake_note(note:)
-        BakeNoteIFrames.v1(note: note)
+        Kichen::Directions::BakeIframes.v1(outer_element: note)
         note.wrap_children(class: 'os-note-body')
 
         BakeNoteSubtitle.v1(note: note)


### PR DESCRIPTION
Issue: #366
It moves `BakeIframes` outside `bake_notes` directory and refactors it to support other elements containing nested iframes.
