### PR TITLE
Fix bake_note parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Small fix for parameter in `bake_note` definition (minor)
 ## [11.1.0] - 2021-08-30
 
 * Update injected questions to synthesize ids during baking (minor)

--- a/lib/kitchen/directions/bake_notes/bake_autotitled_notes.rb
+++ b/lib/kitchen/directions/bake_notes/bake_autotitled_notes.rb
@@ -11,7 +11,7 @@ module Kitchen
         end
       end
 
-      def self.bake_note(note:, bake_subtitle:, cases: false)
+      def self.bake_note(note:, bake_subtitle:, cases:)
         Kitchen::Directions::BakeIframes.v1(outer_element: note)
         note.wrap_children(class: 'os-note-body')
 


### PR DESCRIPTION
There is no need to set default value in `bake_note` cases parameter. It's defined in V1 definition:

![image](https://user-images.githubusercontent.com/40228854/131479784-3c6467c0-a07b-4645-9a0a-a089541bd193.png)
