### PR TITLE
BakeNumberedNotes.v3 Related Example fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 * Adds `BakeAccessibilityFixes` direction for (minor)
 * Remove deprecation warning from `BakeChapterIntroductions.v1` and adapted to be used like `.v2` (minor)
+* Fix `BakeNumberedNotes` to find related example better (minor)
 
 * Small fix for parameter in `bake_note` definition (minor)
 ## [11.1.0] - 2021-08-30

--- a/lib/kitchen/directions/bake_notes/bake_numbered_notes/v3.rb
+++ b/lib/kitchen/directions/bake_notes/bake_numbered_notes/v3.rb
@@ -9,6 +9,9 @@ module Kitchen::Directions
           book.chapters.pages.notes("$.#{klass}").each do |note|
             note.wrap_children(class: 'os-note-body')
             previous_example = note.previous
+            until previous_example.nil? || previous_example[:'data-type'] == 'example'
+              previous_example = previous_example.previous
+            end
             os_number = previous_example&.first('.os-number')&.children&.to_s
 
             note.prepend(child:

--- a/spec/directions/bake_notes/bake_numbered_notes/v3_spec.rb
+++ b/spec/directions/bake_notes/bake_numbered_notes/v3_spec.rb
@@ -7,29 +7,30 @@ RSpec.describe Kitchen::Directions::BakeNumberedNotes::V3 do
     book_containing(html:
       <<~HTML
         <div data-type="chapter"><div data-type="page" id="page_1">
-          <div data-type="exercise">
+          <div data-type="example">
             <span class="os-number">1.1</span>
           </div>
           <div data-type="note" id="123" class="foo">
             <p>content 1.1</p>
           </div>
-          <div data-type="exercise">
+          <div data-type="example">
             <span class="os-number">1.2</span>
           </div>
-          <div data-type="exercise">
+          <div data-type="example">
             <span class="os-number">1.3</span>
           </div>
 
           <div data-type="note" id="111" class="hello">
             <p>content 1.3</p>
           </div>
-          <div data-type="exercise">
+          <div data-type="example">
             <span class="os-number">1.4</span>
             <figure>
               <span class="os-title">Figure</span>
               <span class="os-number">1.1</span>
             </figure>
           </div>
+
           <div data-type="note" id="222" class="hello">
             <p>content 1.4</p>
           </div>
@@ -44,7 +45,7 @@ RSpec.describe Kitchen::Directions::BakeNumberedNotes::V3 do
               <div data-type="problem">what is your quest?</div>
             </div>
           </div>
-          <div data-type="exercise">
+          <div data-type="example">
             <span class="os-number">2.2</span>
           </div>
           <div data-type="note" id="333" class="hello">
@@ -56,12 +57,18 @@ RSpec.describe Kitchen::Directions::BakeNumberedNotes::V3 do
               </div>
             </div>
           </div>
+          <div data-type="example">
+            <span class="os-number">2.3</span>
+          </div>
           <div data-type="note" id="000" class=":/">
             <p>don't bake me</p>
           </div>
           <div data-type="note" id="note_id15" class="theorem" use-subtitle="true">
             <div data-type="title" id="title_id15">Two Important Limits</div>
             <p> some content </p>
+          </div>
+          <div data-type="example">
+            <span class="os-number">2.4</span>
           </div>
           <div data-type="note" id="4" class="foo">
             <p>A title 4</p>
@@ -78,6 +85,12 @@ RSpec.describe Kitchen::Directions::BakeNumberedNotes::V3 do
               </div>
             </div>
           </div>
+          <div data-type="example">
+            <span class="os-number">2.5</span>
+          </div>
+          <table>
+            <th>Some Relevant Data</th>
+          </table>
           <div data-type="note" id="123" class="foo">
             <p>note with injected exercise</p>
             <div data-type="injected-exercise">
@@ -114,7 +127,7 @@ RSpec.describe Kitchen::Directions::BakeNumberedNotes::V3 do
       <<~HTML
         <body>
           <div data-type="chapter"><div data-type="page" id="page_1">
-            <div data-type="exercise">
+            <div data-type="example">
               <span class="os-number">1.1</span>
             </div>
             <div class="foo" data-type="note" id="123">
@@ -126,10 +139,10 @@ RSpec.describe Kitchen::Directions::BakeNumberedNotes::V3 do
                 <p>content 1.1</p>
               </div>
             </div>
-            <div data-type="exercise">
+            <div data-type="example">
               <span class="os-number">1.2</span>
             </div>
-            <div data-type="exercise">
+            <div data-type="example">
               <span class="os-number">1.3</span>
             </div>
             <div class="hello" data-type="note" id="111">
@@ -141,7 +154,7 @@ RSpec.describe Kitchen::Directions::BakeNumberedNotes::V3 do
                 <p>content 1.3</p>
               </div>
             </div>
-            <div data-type="exercise">
+            <div data-type="example">
               <span class="os-number">1.4</span>
               <figure>
                 <span class="os-title">Figure</span>
@@ -182,7 +195,7 @@ RSpec.describe Kitchen::Directions::BakeNumberedNotes::V3 do
                 </div>
               </div>
             </div>
-            <div data-type="exercise">
+            <div data-type="example">
               <span class="os-number">2.2</span>
             </div>
             <div class="hello" data-type="note" id="333">
@@ -199,22 +212,28 @@ RSpec.describe Kitchen::Directions::BakeNumberedNotes::V3 do
                 </div>
               </div>
             </div>
+            <div data-type="example">
+              <span class="os-number">2.3</span>
+            </div>
             <div data-type="note" id="000" class=":/">
               <p>don't bake me</p>
             </div>
             <div class="theorem" data-type="note" id="note_id15" use-subtitle="true">
               <h3 class="os-title">
                 <span class="os-title-label">Theorem</span>
-                <span class="os-number"></span>
+                <span class="os-number">2.3</span>
               </h3>
               <div class="os-note-body">
                 <p> some content </p>
               </div>
             </div>
+            <div data-type="example">
+              <span class="os-number">2.4</span>
+            </div>
             <div class="foo" data-type="note" id="4">
               <h3 class="os-title">
                 <span class="os-title-label">Bar</span>
-                <span class="os-number"></span>
+                <span class="os-number">2.4</span>
               </h3>
               <div class="os-note-body">
                 <p>A title 4</p>
@@ -230,10 +249,16 @@ RSpec.describe Kitchen::Directions::BakeNumberedNotes::V3 do
                 </div>
               </div>
             </div>
+            <div data-type="example">
+              <span class="os-number">2.5</span>
+            </div>
+            <table>
+              <th>Some Relevant Data</th>
+            </table>
             <div class="foo" data-type="note" id="123">
               <h3 class="os-title">
                 <span class="os-title-label">Bar</span>
-                <span class="os-number"></span>
+                <span class="os-number">2.5</span>
               </h3>
               <div class="os-note-body">
                 <p>note with injected exercise</p>
@@ -243,7 +268,7 @@ RSpec.describe Kitchen::Directions::BakeNumberedNotes::V3 do
                       <div data-type="question-stem">a question stem</div>
                     </div>
                     <div data-type="question-solution" id="auto_2_17-solution">
-                      <a class="os-number" href="#auto_2_17"></a>
+                      <a class="os-number" href="#auto_2_17">2.5</a>
                       <span class="os-divider">. </span>
                       <div class="os-solution-container">
                   some solution


### PR DESCRIPTION
Makes so that BakeNumberedNotes.v3 finds it's related example better by looking past the previous element if it's not what the note expects. 