### PR TITLE
Patch BakeFootnotes.v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 * Adds `BakeAccessibilityFixes` direction for (minor)
 * Remove deprecation warning from `BakeChapterIntroductions.v1` and adapted to be used like `.v2` (minor)
-
+* Small class fix for `BakeFootnotes.v1` (patch)
 * Small fix for parameter in `bake_note` definition (minor)
+
 ## [11.1.0] - 2021-08-30
 
 * Update injected questions to synthesize ids during baking (minor)

--- a/lib/kitchen/directions/bake_footnotes/v1.rb
+++ b/lib/kitchen/directions/bake_footnotes/v1.rb
@@ -28,7 +28,11 @@ module Kitchen::Directions::BakeFootnotes
         anchor.replace_children(with: footnote_number)
         aside_id = anchor[:href][1..-1]
         aside_id_to_footnote_number[aside_id] = footnote_number
-        anchor.parent.add_class('has-noteref') if anchor.parent.name == 'p'
+        if anchor.parent.name == 'p'
+          anchor.parent.add_class('has-noteref')
+        elsif anchor.parent.name == 'em' && anchor.parent.parent.name == 'p'
+          anchor.parent.parent.add_class('has-noteref')
+        end
       end
 
       container.search('aside').each do |aside|

--- a/spec/directions/bake_footnotes/v1_spec.rb
+++ b/spec/directions/bake_footnotes/v1_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Kitchen::Directions::BakeFootnotes::V1 do
           <div data-type="page">
             <p><a href="#aside2" role="doc-noteref">[footnote]</a> Blah.</p>
             <aside id="aside2" type="footnote">Footnote content 2</aside>
-            <p><a href="#aside3" role="doc-noteref">[footnote]</a> Blah.</p>
+            <p><em><a href="#aside3" role="doc-noteref">[footnote]</a> Blah.</em></p>
             <aside id="aside3" type="footnote">Footnote content 3</aside>
           </div>
           <div data-type="page">
@@ -58,7 +58,7 @@ RSpec.describe Kitchen::Directions::BakeFootnotes::V1 do
           <div data-type="page">
             <p class="has-noteref"><a href="#aside2" role="doc-noteref">1</a> Blah.</p>
             <aside id="aside2" type="footnote"><div data-type="footnote-number">1</div>Footnote content 2</aside>
-            <p class="has-noteref"><a href="#aside3" role="doc-noteref">2</a> Blah.</p>
+            <p class="has-noteref"><em><a href="#aside3" role="doc-noteref">2</a> Blah.</em></p>
             <aside id="aside3" type="footnote"><div data-type="footnote-number">2</div>Footnote content 3</aside>
           </div>
           <div data-type="page">
@@ -101,7 +101,7 @@ RSpec.describe Kitchen::Directions::BakeFootnotes::V1 do
           <div data-type="page">
             <p class="has-noteref"><a href="#aside2" role="doc-noteref">i</a> Blah.</p>
             <aside id="aside2" type="footnote"><div data-type="footnote-number">i</div>Footnote content 2</aside>
-            <p class="has-noteref"><a href="#aside3" role="doc-noteref">ii</a> Blah.</p>
+            <p class="has-noteref"><em><a href="#aside3" role="doc-noteref">ii</a> Blah.</em></p>
             <aside id="aside3" type="footnote"><div data-type="footnote-number">ii</div>Footnote content 3</aside>
           </div>
           <div data-type="page">


### PR DESCRIPTION
So that it will correctly tag paragraphs with 'has-noteref' even if the footnote is in an 'em' tag within the paragraph.