### PR TITLE
Learning Objectives sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Create V3 in `BakePageAbstracts` for Learning Objectives sections (minor)
 * Adds an optional selector to `RemoveSectionTitles` (minor)
 
 ## [11.2.0] - 2021-09-10

--- a/lib/kitchen/directions/bake_page_abstracts.rb
+++ b/lib/kitchen/directions/bake_page_abstracts.rb
@@ -13,16 +13,26 @@ module Kitchen
       def self.v2(chapter:)
         chapter.abstracts.each do |abstract|
           abstract.prepend(child: "<h3 data-type='title'>#{I18n.t(:learning_objectives)}</h3>")
-          ul = abstract.first!('ul')
-          ul.add_class('os-abstract')
-          ul.search('li').each_with_index do |li, index|
-            li.replace_children(with:
-              <<~HTML
-                <span class="os-abstract-token">#{chapter.count_in(:book)}.#{abstract.count_in(:chapter)}.#{index + 1}</span>
-                <span class="os-abstract-content">#{li.children}</span>
-              HTML
-            )
-          end
+          modify_abstract_list(chapter: chapter, element: abstract)
+        end
+      end
+
+      def self.v3(chapter:)
+        chapter.search('section.learning-objectives').each do |learning_objective|
+          modify_abstract_list(chapter: chapter, element: learning_objective)
+        end
+      end
+
+      def self.modify_abstract_list(chapter:, element:)
+        ul = element.first!('ul')
+        ul.add_class('os-abstract')
+        ul.search('li').each_with_index do |li, index|
+          li.replace_children(with:
+            <<~HTML
+              <span class="os-abstract-token">#{chapter.count_in(:book)}.#{element.count_in(:chapter)}.#{index + 1}</span>
+              <span class="os-abstract-content">#{li.children}</span>
+            HTML
+          )
         end
       end
     end

--- a/spec/directions/bake_page_abstracts_spec.rb
+++ b/spec/directions/bake_page_abstracts_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Kitchen::Directions::BakePageAbstracts do
     })
   end
 
-  let(:chapter) do
+  let(:chapter_with_abstract) do
     book_containing(html:
       <<~HTML
         <div data-type="chapter">
@@ -30,38 +30,89 @@ RSpec.describe Kitchen::Directions::BakePageAbstracts do
     ).chapters.first
   end
 
-  it 'adds Learning Objectives h3' do
-    described_class.v1(chapter: chapter)
-    expect(chapter).to match_normalized_html(
+  let(:chapter_with_learning_objectives) do
+    book_containing(html:
       <<~HTML
         <div data-type="chapter">
           <h1 data-type="document-title">Chapter 1 title</h1>
-          <div class="introduction" data-type="page">Chapter intro</div>
-          <div class="chapter-content-module" data-type="page">
-            <h2 data-type="document-title">Module 1.1 title</h2>
-            <div data-type="abstract">
+          <div data-type="page" class="introduction">Chapter intro</div>
+          <div data-type="page" class="chapter-content-module">
+            <h2 data-type="document-title">Module 1.1 title</div>
+            <section class="learning-objectives">
               <h3 data-type="title">Learning Objectives</h3>
-              By the end of this module, you will be able to:
-                <ul><li>Outline the historical development of chemistry</li><li>Provide examples of the importance of chemistry in everyday life</li></ul>
-              </div>
+              <p>By the end of this module, you will be able to:</p>
+              <ul>
+                <li>Outline the historical development of chemistry</li>
+                <li>Provide examples of the importance of chemistry in everyday life</li>
+              </ul>
+            </section>
           </div>
         </div>
       HTML
-    )
+    ).chapters.first
   end
 
-  it 'adds abstract-token and abstract-content' do
-    described_class.v2(chapter: chapter)
-    expect(chapter.non_introduction_pages).to match_normalized_html(
-      <<~HTML
-        <div class="chapter-content-module" data-type="page">
-          <h2 data-type="document-title">Module 1.1 title</h2>
-          <div data-type="abstract"><h3 data-type="title">Learning Objectives</h3>
-              By the end of this module, you will be able to:
-                <ul class="os-abstract"><li><span class="os-abstract-token">1.1.1</span><span class="os-abstract-content">Outline the historical development of chemistry</span></li><li><span class="os-abstract-token">1.1.2</span><span class="os-abstract-content">Provide examples of the importance of chemistry in everyday life</span></li></ul>
-              </div>
-        </div>
-      HTML
-    )
+  context 'when chapter has abstract created from metadata' do
+    it 'adds Learning Objectives h3' do
+      described_class.v1(chapter: chapter_with_abstract)
+      expect(chapter_with_abstract).to match_normalized_html(
+        <<~HTML
+          <div data-type="chapter">
+            <h1 data-type="document-title">Chapter 1 title</h1>
+            <div class="introduction" data-type="page">Chapter intro</div>
+            <div class="chapter-content-module" data-type="page">
+              <h2 data-type="document-title">Module 1.1 title</h2>
+              <div data-type="abstract">
+                <h3 data-type="title">Learning Objectives</h3>
+                By the end of this module, you will be able to:
+                  <ul><li>Outline the historical development of chemistry</li><li>Provide examples of the importance of chemistry in everyday life</li></ul>
+                </div>
+            </div>
+          </div>
+        HTML
+      )
+    end
+
+    it 'adds abstract-token and abstract-content' do
+      described_class.v2(chapter: chapter_with_abstract)
+      expect(chapter_with_abstract.non_introduction_pages).to match_normalized_html(
+        <<~HTML
+          <div class="chapter-content-module" data-type="page">
+            <h2 data-type="document-title">Module 1.1 title</h2>
+            <div data-type="abstract"><h3 data-type="title">Learning Objectives</h3>
+                By the end of this module, you will be able to:
+                  <ul class="os-abstract"><li><span class="os-abstract-token">1.1.1</span><span class="os-abstract-content">Outline the historical development of chemistry</span></li><li><span class="os-abstract-token">1.1.2</span><span class="os-abstract-content">Provide examples of the importance of chemistry in everyday life</span></li></ul>
+                </div>
+          </div>
+        HTML
+      )
+    end
+  end
+
+  context 'when chapter has section with learning-objectives class' do
+    it 'adds abstract-token and abstract-content' do
+      described_class.v3(chapter: chapter_with_learning_objectives)
+      expect(chapter_with_learning_objectives.non_introduction_pages).to match_normalized_html(
+        <<~HTML
+          <div class="chapter-content-module" data-type="page">
+            <h2 data-type="document-title">Module 1.1 title</h2>
+            <section class="learning-objectives">
+              <h3 data-type="title">Learning Objectives</h3>
+                <p>By the end of this module, you will be able to:</p>
+                  <ul class="os-abstract">
+                    <li>
+                      <span class="os-abstract-token">1.1.1</span>
+                      <span class="os-abstract-content">Outline the historical development of chemistry</span>
+                    </li>
+                    <li>
+                      <span class="os-abstract-token">1.1.2</span>
+                      <span class="os-abstract-content">Provide examples of the importance of chemistry in everyday life</span>
+                    </li>
+                  </ul>
+            </section>
+          </div>
+        HTML
+      )
+    end
   end
 end

--- a/spec/directions/bake_page_abstracts_spec.rb
+++ b/spec/directions/bake_page_abstracts_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Kitchen::Directions::BakePageAbstracts do
           <h1 data-type="document-title">Chapter 1 title</h1>
           <div data-type="page" class="introduction">Chapter intro</div>
           <div data-type="page" class="chapter-content-module">
-            <h2 data-type="document-title">Module 1.1 title</div>
+            <h2 data-type="document-title">Module 1.1 title</h2>
             <div data-type="abstract">
               By the end of this module, you will be able to:
                 <ul>
@@ -37,7 +37,7 @@ RSpec.describe Kitchen::Directions::BakePageAbstracts do
           <h1 data-type="document-title">Chapter 1 title</h1>
           <div data-type="page" class="introduction">Chapter intro</div>
           <div data-type="page" class="chapter-content-module">
-            <h2 data-type="document-title">Module 1.1 title</div>
+            <h2 data-type="document-title">Module 1.1 title</h2>
             <section class="learning-objectives">
               <h3 data-type="title">Learning Objectives</h3>
               <p>By the end of this module, you will be able to:</p>


### PR DESCRIPTION
In BCA Learning Objectives is a section with class `learning-objectives` and existing title, no div with `data-type="abstract"` created from metadata. Only thing that should be done during baking is numbering.