### PR TITLE
BakeNumberedNotes.v3 patch

### DIFF
--- a/lib/kitchen/directions/bake_notes/bake_numbered_notes/v3.rb
+++ b/lib/kitchen/directions/bake_notes/bake_numbered_notes/v3.rb
@@ -32,6 +32,8 @@ module Kitchen::Directions
             note.injected_questions.each do |question|
               BakeNumberedNotes.bake_note_injected_question(note: note, question: question)
             end
+
+            note.search("div[data-type='solution']").each&.trash if suppress_solution
           end
         end
       end

--- a/spec/directions/bake_notes/bake_numbered_notes/v3_spec.rb
+++ b/spec/directions/bake_notes/bake_numbered_notes/v3_spec.rb
@@ -102,6 +102,12 @@ RSpec.describe Kitchen::Directions::BakeNumberedNotes::V3 do
               </div>
             </div>
           </div>
+          <div data-type="note" id="123" class="foo">
+            <p>note with solution to be suppressed</p>
+            <div data-type="solution">
+              <p>Some Solution</p>
+            </div>
+          </div>
         </div></div>
       HTML
     )
@@ -276,6 +282,15 @@ RSpec.describe Kitchen::Directions::BakeNumberedNotes::V3 do
                     </div>
                   </div>
                 </div>
+              </div>
+            </div>
+            <div data-type="note" id="123" class="foo">
+              <h3 class="os-title">
+                <span class="os-title-label">Bar</span>
+                <span class="os-number">2.5</span>
+              </h3>
+              <div class="os-note-body">
+                <p>note with solution to be suppressed</p>
               </div>
             </div>
           </div></div>


### PR DESCRIPTION
suppress_solution will now suppress solutions that are outside of an exercise in a note.