### PR TITLE
Rework AddInjectedExerciseId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Modify `BakeAutotitledNotes` to bake unnumbered exercises with solution (minor)
 * Create `AddInjectedExerciseId` to separate creating ids from `BakeInjectedExerciseQuestion` (minor)
+* Rework `AddInjectedExerciseId` to use loop inside module (minor)
 
 ## [12.1.0] - 2021-09-24
 

--- a/lib/kitchen/directions/bake_injected_exercise/add_injected_exercise_id.rb
+++ b/lib/kitchen/directions/bake_injected_exercise/add_injected_exercise_id.rb
@@ -8,8 +8,8 @@ module Kitchen
     # In some books exercises are numbered after moving.
     # That's why this step has to be separated from BakeInjectedExerciseQuestion
     module AddInjectedExerciseId
-      def self.v1(question:)
-        question.id
+      def self.v1(book:)
+        book.pages.injected_questions.each(&:id)
       end
     end
   end

--- a/spec/directions/bake_injected_exercise/add_injected_exercise_id_spec.rb
+++ b/spec/directions/bake_injected_exercise/add_injected_exercise_id_spec.rb
@@ -22,9 +22,7 @@ RSpec.describe Kitchen::Directions::AddInjectedExerciseId do
   end
 
   it 'bakes' do
-    book_with_injected_section.chapters.pages.injected_questions.each do |question|
-      described_class.v1(question: question)
-    end
+    described_class.v1(book: book_with_injected_section)
     expect(book_with_injected_section.search('section').first).to match_normalized_html(
       <<~HTML
         <section class="section-with-injected-exercises">


### PR DESCRIPTION
Fix for `AddInjectedExerciseId` to use loop inside module, so in recipe we can simply use: `AddInjectedExerciseId.v1(book: book)`.