### PR TITLE
change whitespace for BakeIndex and BakeExample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Change whitespace for `BakeIndex` and `BakeExample` (major)
 * Add `BakeAllNumberedExerciseTypes` direction for easier baking of compound sections (minor)
 * Add `solution_stays_put` option for `BakeNumberedExercise` (minor)
 * Refactor: moves all `Answer key strategies` that are book-specific to the

--- a/lib/kitchen/directions/bake_example.rb
+++ b/lib/kitchen/directions/bake_example.rb
@@ -39,7 +39,7 @@ module Kitchen
             solution.replace_children(with:
               <<~HTML
                 <h4 data-type="solution-title">
-                  <span class="os-title-label">#{I18n.t(:solution)} </span>
+                  <span class="os-title-label">#{I18n.t(:solution)}</span>
                   #{solution_number}
                 </h4>
                 <div class="os-solution-container">#{solution.children}</div>

--- a/lib/kitchen/directions/bake_index/v1.xhtml.erb
+++ b/lib/kitchen/directions/bake_index/v1.xhtml.erb
@@ -11,16 +11,12 @@
       <span class="group-label"><%= section.name %></span>
       <% section.items.each do |item| %>
         <div class="os-index-item">
-          <% item.terms.each_with_index do |term, ii| %>
-            <% if ii == 0 %>
+          <%- item.terms.each_with_index do |term, ii| -%>
+            <%- if ii == 0 -%>
               <span class="os-term" group-by="<%= term.group_by %>"><%= term.text %></span>
-            <% else %>
-              <span class="os-index-link-separator">, </span>
-            <% end %>
-            <a class="os-term-section-link" href="#<%= term.id %>">
-              <span class="os-term-section"><%= term.page_title %></span>
-            </a>
-          <% end %>
+            <%- else -%><span class="os-index-link-separator">, </span><% end %>
+            <a class="os-term-section-link" href="#<%= term.id %>"><span class="os-term-section"><%= term.page_title %></span></a><!--
+          --><%- end %>
         </div>
       <% end %>
     </div>

--- a/lib/kitchen/patches/renderable.rb
+++ b/lib/kitchen/patches/renderable.rb
@@ -29,7 +29,7 @@ class Object
       def render(file:)
         file = File.absolute_path(file, renderable_base_dir)
         template = File.open(file, 'rb', &:read)
-        ERB.new(template).result(binding)
+        ERB.new(template, trim_mode: '-').result(binding)
       end
     end
   end

--- a/spec/directions/bake_example_spec.rb
+++ b/spec/directions/bake_example_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Kitchen::Directions::BakeExample do
                 </div>
                 <div data-type="solution" id="solution_id">
                   <h4 data-type="solution-title">
-                    <span class="os-title-label">Solution </span>
+                    <span class="os-title-label">Solution</span>
                   </h4>
                   <div class="os-solution-container">
                     <p>Solution content</p>
@@ -155,7 +155,7 @@ RSpec.describe Kitchen::Directions::BakeExample do
                 </div>
                 <div data-type="solution" id="solution_id">
                   <h4 data-type="solution-title">
-                    <span class="os-title-label">Solution </span>
+                    <span class="os-title-label">Solution</span>
                   </h4>
                   <div class="os-solution-container">
                     <p>Solution content</p>
@@ -220,7 +220,7 @@ RSpec.describe Kitchen::Directions::BakeExample do
                 </div>
                 <div data-type="solution" id="solution_id_1">
                   <h4 data-type="solution-title">
-                    <span class="os-title-label">Solution </span>
+                    <span class="os-title-label">Solution</span>
                   </h4>
                   <div class="os-solution-container">
                     <p>Solution content</p>
@@ -228,7 +228,7 @@ RSpec.describe Kitchen::Directions::BakeExample do
                 </div>
                 <div data-type="solution" id="solution_id_2">
                   <h4 data-type="solution-title">
-                    <span class="os-title-label">Solution </span>
+                    <span class="os-title-label">Solution</span>
                   </h4>
                   <div class="os-solution-container">
                     <p>A second solution</p>
@@ -400,7 +400,7 @@ RSpec.describe Kitchen::Directions::BakeExample do
                 </div>
                 <div data-type="solution" id="solution_id">
                   <h4 data-type="solution-title">
-                    <span class="os-title-label">Solution </span>
+                    <span class="os-title-label">Solution</span>
                     <span class="os-number">1</span>
                   </h4>
                   <div class="os-solution-container">
@@ -422,7 +422,7 @@ RSpec.describe Kitchen::Directions::BakeExample do
                 </div>
                 <div data-type="solution" id="solution_id">
                   <h4 data-type="solution-title">
-                    <span class="os-title-label">Solution </span>
+                    <span class="os-title-label">Solution</span>
                     <span class="os-number">2</span>
                   </h4>
                   <div class="os-solution-container">
@@ -509,7 +509,7 @@ RSpec.describe Kitchen::Directions::BakeExample do
                       </div>
                       <div data-type="solution">
                         <h4 data-type="solution-title">
-                          <span class="os-title-label">Solution </span>
+                          <span class="os-title-label">Solution</span>
                         </h4>
                         <div class="os-solution-container">A</div>
                       </div>

--- a/spec/directions/bake_index/v1_context1_spec.rb
+++ b/spec/directions/bake_index/v1_context1_spec.rb
@@ -88,18 +88,24 @@ RSpec.describe Kitchen::Directions::BakeIndex do
                 <a class="os-term-section-link" href="#auto_p2_term9">
                   <span class="os-term-section">1.1 First Page</span>
                 </a>
+                <!--
+                    -->
               </div>
               <div class="os-index-item">
                 <span class="os-term" group-by="Symbols">5&#x2019; cap</span>
                 <a class="os-term-section-link" href="#auto_composite_page_term4">
                   <span class="os-term-section">2 Another EOC Section</span>
                 </a>
+                <!--
+                    -->
               </div>
               <div class="os-index-item">
                 <span class="os-term" group-by="Symbols">&#x394;E</span>
                 <a class="os-term-section-link" href="#auto_p2_term7">
                   <span class="os-term-section">1.1 First Page</span>
                 </a>
+                <!--
+                    -->
               </div>
             </div>
             <div class="group-by">
@@ -109,10 +115,14 @@ RSpec.describe Kitchen::Directions::BakeIndex do
                 <a class="os-term-section-link" href="#auto_p1_term3">
                   <span class="os-term-section">Preface</span>
                 </a>
+                <!--
+                    -->
                 <span class="os-index-link-separator">, </span>
                 <a class="os-term-section-link" href="#auto_p1_term4">
                   <span class="os-term-section">Preface</span>
                 </a>
+                <!--
+                    -->
               </div>
             </div>
             <div class="group-by">
@@ -122,12 +132,16 @@ RSpec.describe Kitchen::Directions::BakeIndex do
                 <a class="os-term-section-link" href="#auto_composite_page_term2">
                   <span class="os-term-section">2 Another EOC Section</span>
                 </a>
+                <!--
+                    -->
               </div>
               <div class="os-index-item">
                 <span class="os-term" group-by="c">composite page in a composite chapter</span>
                 <a class="os-term-section-link" href="#auto_composite_page_term1">
                   <span class="os-term-section">1 EOC Section Title</span>
                 </a>
+                <!--
+                    -->
               </div>
             </div>
             <div class="group-by">
@@ -137,6 +151,8 @@ RSpec.describe Kitchen::Directions::BakeIndex do
                 <a class="os-term-section-link" href="#auto_composite_page_term3">
                   <span class="os-term-section">2 Another EOC Section</span>
                 </a>
+                <!--
+                    -->
               </div>
             </div>
             <div class="group-by">
@@ -146,14 +162,20 @@ RSpec.describe Kitchen::Directions::BakeIndex do
                 <a class="os-term-section-link" href="#auto_p1_term1">
                   <span class="os-term-section">Preface</span>
                 </a>
+                <!--
+                    -->
                 <span class="os-index-link-separator">, </span>
                 <a class="os-term-section-link" href="#auto_p1_term2">
                   <span class="os-term-section">Preface</span>
                 </a>
+                <!--
+                    -->
                 <span class="os-index-link-separator">, </span>
                 <a class="os-term-section-link" href="#auto_p2_term6">
                   <span class="os-term-section">1.1 First Page</span>
                 </a>
+                <!--
+                    -->
               </div>
             </div>
             <div class="group-by">
@@ -163,6 +185,8 @@ RSpec.describe Kitchen::Directions::BakeIndex do
                 <a class="os-term-section-link" href="#auto_p1_term5">
                   <span class="os-term-section">Preface</span>
                 </a>
+                <!--
+                    -->
               </div>
             </div>
             <div class="group-by">
@@ -172,6 +196,8 @@ RSpec.describe Kitchen::Directions::BakeIndex do
                 <a class="os-term-section-link" href="#auto_p2_term8">
                   <span class="os-term-section">1.1 First Page</span>
                 </a>
+                <!--
+                    -->
               </div>
             </div>
           </div>

--- a/spec/directions/bake_index/v1_context2_spec.rb
+++ b/spec/directions/bake_index/v1_context2_spec.rb
@@ -153,10 +153,14 @@ RSpec.describe Kitchen::Directions::BakeIndex do
                   <a class="os-term-section-link" href="#auto_p1_term3">
                     <span class="os-term-section">Preface</span>
                   </a>
+                  <!--
+                    -->
                   <span class="os-index-link-separator">, </span>
                   <a class="os-term-section-link" href="#auto_p2_term11">
                     <span class="os-term-section">1.1 First Page</span>
                   </a>
+                  <!--
+                    -->
                 </div>
               </div>
               <div class="group-by">
@@ -166,6 +170,8 @@ RSpec.describe Kitchen::Directions::BakeIndex do
                   <a class="os-term-section-link" href="#auto_p2_term10">
                     <span class="os-term-section">1.1 First Page</span>
                   </a>
+                  <!--
+                    -->
                 </div>
               </div>
             </div>
@@ -190,6 +196,8 @@ RSpec.describe Kitchen::Directions::BakeIndex do
                   <a class="os-term-section-link" href="#auto_p2_term8">
                     <span class="os-term-section">1.1 First Page</span>
                   </a>
+                  <!--
+                    -->
                 </div>
               </div>
               <div class="group-by">
@@ -199,6 +207,8 @@ RSpec.describe Kitchen::Directions::BakeIndex do
                   <a class="os-term-section-link" href="#auto_p2_term7">
                     <span class="os-term-section">1.1 First Page</span>
                   </a>
+                  <!--
+                    -->
                 </div>
               </div>
               <div class="group-by">
@@ -208,12 +218,16 @@ RSpec.describe Kitchen::Directions::BakeIndex do
                   <a class="os-term-section-link" href="#auto_composite_page_term2">
                     <span class="os-term-section">2 Another EOC Section</span>
                   </a>
+                  <!--
+                    -->
                 </div>
                 <div class="os-index-item">
                   <span class="os-term" group-by="c">composite page in a composite chapter</span>
                   <a class="os-term-section-link" href="#auto_composite_page_term1">
                     <span class="os-term-section">1 EOC Section Title</span>
                   </a>
+                  <!--
+                    -->
                 </div>
               </div>
               <div class="group-by">
@@ -223,14 +237,20 @@ RSpec.describe Kitchen::Directions::BakeIndex do
                   <a class="os-term-section-link" href="#auto_p1_term1">
                     <span class="os-term-section">Preface</span>
                   </a>
+                  <!--
+                    -->
                   <span class="os-index-link-separator">, </span>
                   <a class="os-term-section-link" href="#auto_p1_term2">
                     <span class="os-term-section">Preface</span>
                   </a>
+                  <!--
+                    -->
                   <span class="os-index-link-separator">, </span>
                   <a class="os-term-section-link" href="#auto_p2_term6">
                     <span class="os-term-section">1.1 First Page</span>
                   </a>
+                  <!--
+                    -->
                 </div>
               </div>
               <div class="group-by">
@@ -240,6 +260,8 @@ RSpec.describe Kitchen::Directions::BakeIndex do
                   <a class="os-term-section-link" href="#auto_p2_term9">
                     <span class="os-term-section">1.1 First Page</span>
                   </a>
+                  <!--
+                    -->
                 </div>
               </div>
             </div>
@@ -264,6 +286,8 @@ RSpec.describe Kitchen::Directions::BakeIndex do
                   <a class="os-term-section-link" href="#auto_p1_term4">
                     <span class="os-term-section">Preface</span>
                   </a>
+                  <!--
+                    -->
                 </div>
               </div>
               <div class="group-by">
@@ -273,10 +297,14 @@ RSpec.describe Kitchen::Directions::BakeIndex do
                   <a class="os-term-section-link" href="#auto_p1_term5">
                     <span class="os-term-section">Preface</span>
                   </a>
+                  <!--
+                    -->
                   <span class="os-index-link-separator">, </span>
                   <a class="os-term-section-link" href="#auto_p2_term12">
                     <span class="os-term-section">1.1 First Page</span>
                   </a>
+                  <!--
+                    -->
                 </div>
               </div>
               <div class="group-by">
@@ -286,6 +314,8 @@ RSpec.describe Kitchen::Directions::BakeIndex do
                   <a class="os-term-section-link" href="#auto_p2_term13">
                     <span class="os-term-section">1.1 First Page</span>
                   </a>
+                  <!--
+                    -->
                 </div>
               </div>
             </div>


### PR DESCRIPTION
This change will break specs for books, as it alters the formatting, but it will resolve openstax/cnx-recipes#4180 for english-composition and all other books, once they're updated to the version with this change.

1. Changes the template for `Index` to avoid newlines around comma separators, as newlines in HTML create a space when rendered
2. Also deals with the space after `Solution` in `BakeExample` 😅 