### PR TITLE
Add #preceded_by_text method to Node_Element and Nokigiri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add `#preceded_by_text` method to element_base and the nokigiri patch (minor)
 * Add details of question count to injected exercises in `BakeInjectedExercise` (major)
 * Add target labels to chapter content module pages option in `BakeNonIntroductionPages`, create a separate directory `BakeLOLinkLabels` to add `.label-text`, `.label-counter` spans wrappers for links with `.lo-reference` class (minor)
 * Add `BakeScreenreaderSpans` direction (minor)

--- a/lib/kitchen/element_base.rb
+++ b/lib/kitchen/element_base.rb
@@ -519,6 +519,13 @@ module Kitchen
       )
     end
 
+    # returns boolean
+    # depending on whether there is non-contained text right before the element
+    #
+    def preceded_by_text?
+      raw.preceded_by_text?
+    end
+
     # TODO: make it clear if all of these methods take Element, Node, or String
 
     # If child argument given, prepends it before the element's current children.

--- a/lib/kitchen/element_base.rb
+++ b/lib/kitchen/element_base.rb
@@ -82,9 +82,13 @@ module Kitchen
     #   Set the inner HTML for this element
     #   @see https://www.rubydoc.info/github/sparklemotion/nokogiri/Nokogiri/XML/Node#inner_html=-instance_method Nokogiri::XML::Node#inner_html=
     #   @return Object
+    # @!method preceded_by_text
+    #   Returns true if the immediately preceding sibling is text
+    #   @return Boolean
     def_delegators :@node, :name=, :name, :[], :[]=, :add_class, :remove_class,
                    :text, :wrap, :children, :to_html, :remove_attribute,
-                   :key?, :classes, :path, :inner_html=, :add_previous_sibling
+                   :key?, :classes, :path, :inner_html=, :add_previous_sibling,
+                   :preceded_by_text?
 
     # @!method config
     #   Get the config for this element's document
@@ -515,13 +519,6 @@ module Kitchen
         document: document,
         short_type: "previous(#{short_type})"
       )
-    end
-
-    # returns boolean
-    # depending on whether there is non-contained text right before the element
-    #
-    def preceded_by_text?
-      raw.preceded_by_text?
     end
 
     # TODO: make it clear if all of these methods take Element, Node, or String

--- a/lib/kitchen/element_base.rb
+++ b/lib/kitchen/element_base.rb
@@ -507,7 +507,7 @@ module Kitchen
     # nil if there's no previous sibling
     #
     def previous
-      prev = raw.previous
+      prev = raw.previous_element
       return prev if prev.nil?
 
       Element.new(

--- a/lib/kitchen/element_base.rb
+++ b/lib/kitchen/element_base.rb
@@ -509,7 +509,6 @@ module Kitchen
     #
     def previous
       prev = raw.previous
-      while !prev.nil? && prev.text? do prev = prev.previous end
       return prev if prev.nil?
 
       Element.new(

--- a/lib/kitchen/element_base.rb
+++ b/lib/kitchen/element_base.rb
@@ -502,9 +502,8 @@ module Kitchen
       Element.new(node: raw.parent, document: document, short_type: "parent(#{short_type})")
     end
 
-    # returns previous element
-    # skips double indentations that the nokigiri sometimes picks up
-    # also skips sibling text nodes
+    # returns previous element sibling
+    # (only returns elements or nil)
     # nil if there's no previous sibling
     #
     def previous

--- a/lib/kitchen/element_base.rb
+++ b/lib/kitchen/element_base.rb
@@ -507,7 +507,7 @@ module Kitchen
     # nil if there's no previous sibling
     #
     def previous
-      prev = raw.previous_element
+      prev = raw.previous
       return prev if prev.nil?
 
       Element.new(

--- a/lib/kitchen/element_base.rb
+++ b/lib/kitchen/element_base.rb
@@ -504,10 +504,12 @@ module Kitchen
 
     # returns previous element
     # skips double indentations that the nokigiri sometimes picks up
+    # also skips text belonging to the parent node
     # nil if there's no previous sibling
     #
     def previous
       prev = raw.previous
+      while !prev.nil? && prev.text? do prev = prev.previous end
       return prev if prev.nil?
 
       Element.new(

--- a/lib/kitchen/element_base.rb
+++ b/lib/kitchen/element_base.rb
@@ -504,7 +504,7 @@ module Kitchen
 
     # returns previous element
     # skips double indentations that the nokigiri sometimes picks up
-    # also skips text belonging to the parent node
+    # also skips sibling text nodes
     # nil if there's no previous sibling
     #
     def previous

--- a/lib/kitchen/patches/nokogiri.rb
+++ b/lib/kitchen/patches/nokogiri.rb
@@ -67,6 +67,13 @@ module Nokogiri
         self[:class]&.split || []
       end
 
+      def previous
+        prev = previous_element
+        return nil if prev.nil?
+
+        prev.text? ? prev.previous : prev
+      end
+
       def preceded_by_text?
         prev = previous_sibling
         while !prev.nil? && prev.blank? do prev = prev.previous_sibling end

--- a/lib/kitchen/patches/nokogiri.rb
+++ b/lib/kitchen/patches/nokogiri.rb
@@ -71,7 +71,7 @@ module Nokogiri
         prev = previous_element
         return nil if prev.nil?
 
-        prev.blank? ? prev.previous : prev
+        prev.text? ? prev.previous : prev
       end
 
       def preceded_by_text?

--- a/lib/kitchen/patches/nokogiri.rb
+++ b/lib/kitchen/patches/nokogiri.rb
@@ -74,6 +74,14 @@ module Nokogiri
         prev.blank? ? prev.previous : prev
       end
 
+      def preceded_by_text?
+        prev = previous_sibling
+        while !prev.nil? && prev.blank? do prev = prev.previous_sibling end
+        return false if prev.nil?
+
+        prev.text?
+      end
+
       def self.selector_to_css_nodes(selector)
         # No need to parse the same selector more than once.
         @parsed_selectors ||= {}

--- a/lib/kitchen/patches/nokogiri.rb
+++ b/lib/kitchen/patches/nokogiri.rb
@@ -67,13 +67,6 @@ module Nokogiri
         self[:class]&.split || []
       end
 
-      def previous
-        prev = previous_element
-        return nil if prev.nil?
-
-        prev.text? ? prev.previous : prev
-      end
-
       def preceded_by_text?
         prev = previous_sibling
         while !prev.nil? && prev.blank? do prev = prev.previous_sibling end

--- a/lib/kitchen/patches/nokogiri.rb
+++ b/lib/kitchen/patches/nokogiri.rb
@@ -71,7 +71,7 @@ module Nokogiri
         prev = previous_element
         return nil if prev.nil?
 
-        prev.text? ? prev.previous : prev
+        prev.blank? ? prev.previous : prev
       end
 
       def self.selector_to_css_nodes(selector)

--- a/spec/element_base_spec.rb
+++ b/spec/element_base_spec.rb
@@ -78,6 +78,31 @@ RSpec.describe Kitchen::ElementBase do
     )
   end
 
+  let(:blank_space_book) do
+    book_containing(html:
+      <<~HTML
+        <div data-type="chapter">
+          <h1 data-type="document-title" id="chapTitle1">
+            <span class="os-part-text">Chapter </span>
+            <span class="os-number">1</span>
+            <span class="os-divider"> </span>
+            <span class="os-text" data-type="" itemprop="">Title Text Chapter 1</span>
+          </h1>
+          <div data-type="page">
+            #{metadata_element}
+            <div class="parent">
+
+              <div data-type="note">Reference 1</div>
+              "Some Text"
+
+              <div class="text-above">Reference 1</div>
+            </div>
+          </div>
+        <div>
+      HTML
+    )
+  end
+
   let(:example) { book.first!('div[data-type="example"]') }
 
   let(:para) { book.first!('p') }
@@ -85,6 +110,10 @@ RSpec.describe Kitchen::ElementBase do
   let(:figure) { sibling_book.first!('figure') }
 
   let(:reference) { sibling_book.first!('div.reference') }
+
+  let(:note) { blank_space_book.first!('div[data-type="note"]') }
+
+  let(:text_above) { blank_space_book.first!('div.text-above') }
 
   describe '#initialize' do
     it 'explodes if given a bad document type' do
@@ -164,6 +193,14 @@ RSpec.describe Kitchen::ElementBase do
 
     it 'returns false if previous sibling is an element' do
       expect(figure.preceded_by_text?).to eq false
+    end
+
+    it 'returns false if no previous siblings except blank space' do
+      expect(note.preceded_by_text?).to eq false
+    end
+
+    it 'returns true if preceded by blank space and then text' do
+      expect(text_above.preceded_by_text?).to eq true
     end
   end
 

--- a/spec/element_base_spec.rb
+++ b/spec/element_base_spec.rb
@@ -67,7 +67,11 @@ RSpec.describe Kitchen::ElementBase do
               <p>This is an example.</p>
             </div>
             <figure id="figure1">Who is my closest sibling?</figure>
-            <p>Some other Text</p>
+            <p>
+              <div data-type="note">Reference 1</div>
+              Some other Text
+              <div data-type="note" class="reference">Reference 2</div>
+            </p>
           </div>
         HTML
       )
@@ -79,6 +83,8 @@ RSpec.describe Kitchen::ElementBase do
   let(:para) { book.first!('p') }
 
   let(:figure) { sibling_book.first!('figure') }
+
+  let(:reference) { sibling_book.first!('div.reference') }
 
   describe '#initialize' do
     it 'explodes if given a bad document type' do
@@ -130,6 +136,14 @@ RSpec.describe Kitchen::ElementBase do
           <div data-type="example" class="class1" id="example1">
             <p>This is an example.</p>
           </div>
+        HTML
+      )
+    end
+
+    it 'skips text belonging to a parent element' do
+      expect(reference.previous).to match_normalized_html(
+        <<~HTML
+          <div data-type="note">Reference 1</div>
         HTML
       )
     end

--- a/spec/element_base_spec.rb
+++ b/spec/element_base_spec.rb
@@ -95,6 +95,7 @@ RSpec.describe Kitchen::ElementBase do
               <div data-type="note">Reference 1</div>
               "Some Text"
 
+
               <div class="text-above">Reference 1</div>
             </div>
           </div>
@@ -169,16 +170,16 @@ RSpec.describe Kitchen::ElementBase do
       )
     end
 
-    it 'skips text belonging to a parent element' do
-      expect(reference.previous).to match_normalized_html(
+    it 'returns nil when a previous sibling does not exist' do
+      expect(para.previous).to eq nil
+    end
+
+    it 'skips over sibling text and blank lines' do
+      expect(text_above.previous).to match_normalized_html(
         <<~HTML
           <div data-type="note">Reference 1</div>
         HTML
       )
-    end
-
-    it 'returns nil when a previous sibling does not exist' do
-      expect(para.previous).to eq nil
     end
   end
 

--- a/spec/element_base_spec.rb
+++ b/spec/element_base_spec.rb
@@ -153,6 +153,20 @@ RSpec.describe Kitchen::ElementBase do
     end
   end
 
+  describe '#preceded_by_text?' do
+    it 'returns true if preceded by text' do
+      expect(reference.preceded_by_text?).to eq true
+    end
+
+    it 'returns false if no previous siblings' do
+      expect(example.preceded_by_text?).to eq false
+    end
+
+    it 'returns false if previous sibling is an element' do
+      expect(figure.preceded_by_text?).to eq false
+    end
+  end
+
   describe '#set' do
     it 'changes the tag name of an element' do
       book.set(:name, 'section')

--- a/spec/element_base_spec.rb
+++ b/spec/element_base_spec.rb
@@ -95,7 +95,6 @@ RSpec.describe Kitchen::ElementBase do
               <div data-type="note">Reference 1</div>
               "Some Text"
 
-
               <div class="text-above">Reference 1</div>
             </div>
           </div>
@@ -170,16 +169,16 @@ RSpec.describe Kitchen::ElementBase do
       )
     end
 
-    it 'returns nil when a previous sibling does not exist' do
-      expect(para.previous).to eq nil
-    end
-
-    it 'skips over sibling text and blank lines' do
-      expect(text_above.previous).to match_normalized_html(
+    it 'skips text belonging to a parent element' do
+      expect(reference.previous).to match_normalized_html(
         <<~HTML
           <div data-type="note">Reference 1</div>
         HTML
       )
+    end
+
+    it 'returns nil when a previous sibling does not exist' do
+      expect(para.previous).to eq nil
     end
   end
 


### PR DESCRIPTION
Figures and tables need a #previous method that returns the previous node (while not returning empty spaces or text not wrapped in a node)

[Anna's reference PR ](https://github.com/openstax/kitchen/pull/443/files) needs a #previous method that does not return empty spaces (like newlines or tabs) but DOES return unwrapped text if it occurs immediately previous. (It's checking whether or not a comma needs to go in between similar elements)

Edit: Changed to add a #preceded_by_text? method in node_element and nokigiri.

Edit2: We might not need the nokigiri patched #previous method?