### PR TITLE
patch caption selection for `BakeNumberedTable#v2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Broaden caption selection for `BakeNumberedTable#v2` (patch)
 * Add details of question count to injected exercises in `BakeInjectedExercise` (major)
 * Add target labels to chapter content module pages option in `BakeNonIntroductionPages`, create a separate directory `BakeLOLinkLabels` to add `.label-text`, `.label-counter` spans wrappers for links with `.lo-reference` class (minor)
 * Add `BakeScreenreaderSpans` direction (minor)

--- a/lib/kitchen/directions/bake_numbered_table/v2.rb
+++ b/lib/kitchen/directions/bake_numbered_table/v2.rb
@@ -9,7 +9,8 @@ module Kitchen::Directions::BakeNumberedTable
       Kitchen::Directions::BakeTableBody::V1.new.bake(table: table, number: number, cases: cases)
 
       caption = ''
-      if table&.caption&.first("span[data-type='title']") && !table.top_captioned?
+      if (table&.caption&.first("span[data-type='title']") || table&.caption) \
+        && !table.top_captioned?
         caption_el = table.caption
         caption_el.add_class('os-caption')
         caption_el.name = 'span'

--- a/spec/directions/bake_numbered_table/v2_spec.rb
+++ b/spec/directions/bake_numbered_table/v2_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Kitchen::Directions::BakeNumberedTable::V2 do
 
   it 'another way of table captioning' do
     described_class.new.bake(table: table_with_only_caption_title, number: 'S')
-    expect(table_with_only_caption_title.document.search('.os-table')).to match_normalized_html(
+    expect(table_with_only_caption_title.document.search('.os-table').first).to match_normalized_html(
       <<~HTML
         <div class="os-table">
           <table class="some-class" id="tId">

--- a/spec/directions/bake_numbered_table/v2_spec.rb
+++ b/spec/directions/bake_numbered_table/v2_spec.rb
@@ -35,6 +35,19 @@ RSpec.describe Kitchen::Directions::BakeNumberedTable::V2 do
     ).tables.first
   end
 
+  let(:table_with_simple_caption) do
+    book_containing(html:
+      one_chapter_with_one_page_containing(
+        <<~HTML
+          <table class="some-class" id="tId">
+            <caption>Table caption</caption>
+            <tbody/>
+          </table>
+        HTML
+      )
+    ).tables.first
+  end
+
   let(:top_captioned_table) do
     book_containing(html:
       one_chapter_with_one_page_containing(
@@ -60,7 +73,7 @@ RSpec.describe Kitchen::Directions::BakeNumberedTable::V2 do
 
   it 'another way of table captioning' do
     described_class.new.bake(table: table_with_only_caption_title, number: 'S')
-    expect(table_with_only_caption_title.document.search('.os-table').first).to match_normalized_html(
+    expect(table_with_only_caption_title.document.search('.os-table')).to match_normalized_html(
       <<~HTML
         <div class="os-table">
           <table class="some-class" id="tId">
@@ -85,6 +98,25 @@ RSpec.describe Kitchen::Directions::BakeNumberedTable::V2 do
             <span class="os-caption">
               <span data-type="title">Secret Title</span>
             </span>
+          </div>
+        </div>
+      HTML
+    )
+  end
+
+  it 'still works when caption doesn\'t have title' do
+    described_class.new.bake(table: table_with_simple_caption, number: '2')
+    expect(table_with_simple_caption.document.search('.os-table')).to match_normalized_html(
+      <<~HTML
+        <div class="os-table">
+          <table class="some-class" id="tId">
+            <tbody></tbody>
+          </table>
+          <div class="os-caption-container">
+            <span class="os-title-label">Table </span>
+            <span class="os-number">2</span>
+            <span class="os-divider"> </span>
+            <span class="os-caption">Table caption</span>
           </div>
         </div>
       HTML


### PR DESCRIPTION
- for `college-success`
- ran rspec in recipes on other books (precal bundle and pl-psych) that call `BakeNumberedTable#v2` and verified that this change doesn't impact them