### PR TITLE
Remove #previous nokigiri patch, use previous_element instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add reference link separator to `BakeReferences.v1` (patch)
 * Modify `BakeFootnotes` to be more general (minor)
 * Add `#preceded_by_text` method to element_base and the nokigiri patch (minor)
+* Remove `Nokigiri#previous` patch, `ElementBase#previous` now uses `#previous_element` (minor)
 * Broaden caption selection for `BakeNumberedTable#v2` (patch)
 * Add details of question count to injected exercises in `BakeInjectedExercise` (major)
 * Add target labels to chapter content module pages option in `BakeNonIntroductionPages`, create a separate directory `BakeLOLinkLabels` to add `.label-text`, `.label-counter` spans wrappers for links with `.lo-reference` class (minor)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Remove `Nokigiri#previous` patch, `ElementBase#previous` now uses `#previous_element` (minor)
 
 ## [16.0.0] - 2021-11-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Modify `BakeFootnotes` to be more general (minor)
 * Add `#preceded_by_text` method to element_base and the nokigiri patch (minor)
 * Broaden caption selection for `BakeNumberedTable#v2` (patch)
 * Add details of question count to injected exercises in `BakeInjectedExercise` (major)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+
+## [16.0.0] - 2021-11-19
+
 * Add reference link separator to `BakeReferences.v1` (patch)
 * Modify `BakeFootnotes` to be more general (minor)
 * Add `#preceded_by_text` method to element_base and the nokigiri patch (minor)
@@ -17,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Create v3 for autotitled exercises with os-hasSolution class
 
 ## [15.0.0] - 2021-11-05
+
 * Add unstyled tables to `BakeTableBody` (minor)
 * Add to `BakeNumberedExercises` rules for baking exercises in appendecies (minor)
 * Add `BakeUnnumberedExercise` direction (minor)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add `#preceded_by_text` method to element_base and the nokigiri patch (minor)
 * Broaden caption selection for `BakeNumberedTable#v2` (patch)
 * Add details of question count to injected exercises in `BakeInjectedExercise` (major)
 * Add target labels to chapter content module pages option in `BakeNonIntroductionPages`, create a separate directory `BakeLOLinkLabels` to add `.label-text`, `.label-counter` spans wrappers for links with `.lo-reference` class (minor)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+* Add reference link separator to `BakeReferences.v1` (patch)
 * Modify `BakeFootnotes` to be more general (minor)
 * Add `#preceded_by_text` method to element_base and the nokigiri patch (minor)
 * Broaden caption selection for `BakeNumberedTable#v2` (patch)
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Create v3 for autotitled exercises with os-hasSolution class
 
 ## [15.0.0] - 2021-11-05
-
 * Add unstyled tables to `BakeTableBody` (minor)
 * Add to `BakeNumberedExercises` rules for baking exercises in appendecies (minor)
 * Add `BakeUnnumberedExercise` direction (minor)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openstax_kitchen (15.0.0)
+    openstax_kitchen (16.0.0)
       activesupport
       i18n
       nokogiri
@@ -99,7 +99,7 @@ GEM
       tins (~> 1.0)
     tins (1.26.0)
       sync
-    twitter_cldr (6.7.0)
+    twitter_cldr (6.8.0)
       camertron-eprun
       cldr-plurals-runtime-rb (~> 1.1)
       tzinfo

--- a/lib/kitchen/directions/bake_footnotes/v1.rb
+++ b/lib/kitchen/directions/bake_footnotes/v1.rb
@@ -30,7 +30,7 @@ module Kitchen::Directions::BakeFootnotes
         aside_id_to_footnote_number[aside_id] = footnote_number
         if anchor.parent.name == 'p'
           anchor.parent.add_class('has-noteref')
-        elsif anchor.parent.name == 'em' && anchor.parent.parent.name == 'p'
+        elsif anchor.parent.name != 'p' && anchor.parent.parent.name == 'p'
           anchor.parent.parent.add_class('has-noteref')
         end
       end

--- a/lib/kitchen/directions/bake_references/v1.rb
+++ b/lib/kitchen/directions/bake_references/v1.rb
@@ -12,6 +12,19 @@ module Kitchen::Directions::BakeReferences
               <sup class="os-citation-number">#{link.count_in(:chapter)}</sup>
             HTML
           )
+
+          next if link.nil?
+
+          link_sibling = link.previous unless link.preceded_by_text?
+          next if link_sibling.nil?
+
+          next unless link_sibling&.raw&.attr('data-type') == 'cite'
+
+          link.prepend(sibling:
+            <<~HTML
+              <span class="os-reference-link-separator">, </span>
+            HTML
+            )
         end
 
         chapter.references.each do |reference|

--- a/lib/kitchen/element_base.rb
+++ b/lib/kitchen/element_base.rb
@@ -511,7 +511,7 @@ module Kitchen
     # nil if there's no previous sibling
     #
     def previous
-      prev = raw.previous
+      prev = raw.previous_element
       return prev if prev.nil?
 
       Element.new(

--- a/lib/kitchen/element_base.rb
+++ b/lib/kitchen/element_base.rb
@@ -82,9 +82,13 @@ module Kitchen
     #   Set the inner HTML for this element
     #   @see https://www.rubydoc.info/github/sparklemotion/nokogiri/Nokogiri/XML/Node#inner_html=-instance_method Nokogiri::XML::Node#inner_html=
     #   @return Object
+    # @!method preceded_by_text
+    #   Returns true if the immediately preceding sibling is text
+    #   @return Boolean
     def_delegators :@node, :name=, :name, :[], :[]=, :add_class, :remove_class,
                    :text, :wrap, :children, :to_html, :remove_attribute,
-                   :key?, :classes, :path, :inner_html=, :add_previous_sibling
+                   :key?, :classes, :path, :inner_html=, :add_previous_sibling,
+                   :preceded_by_text?
 
     # @!method config
     #   Get the config for this element's document
@@ -502,8 +506,8 @@ module Kitchen
       Element.new(node: raw.parent, document: document, short_type: "parent(#{short_type})")
     end
 
-    # returns previous element
-    # skips double indentations that the nokigiri sometimes picks up
+    # returns previous element sibling
+    # (only returns elements or nil)
     # nil if there's no previous sibling
     #
     def previous

--- a/lib/kitchen/patches/nokogiri.rb
+++ b/lib/kitchen/patches/nokogiri.rb
@@ -67,13 +67,6 @@ module Nokogiri
         self[:class]&.split || []
       end
 
-      def previous
-        prev = previous_element
-        return nil if prev.nil?
-
-        prev.text? ? prev.previous : prev
-      end
-
       def preceded_by_text?
         prev = previous_sibling
         while !prev.nil? && prev.blank? do prev = prev.previous_sibling end

--- a/lib/kitchen/patches/nokogiri.rb
+++ b/lib/kitchen/patches/nokogiri.rb
@@ -74,6 +74,14 @@ module Nokogiri
         prev.text? ? prev.previous : prev
       end
 
+      def preceded_by_text?
+        prev = previous_sibling
+        while !prev.nil? && prev.blank? do prev = prev.previous_sibling end
+        return false if prev.nil?
+
+        prev.text?
+      end
+
       def self.selector_to_css_nodes(selector)
         # No need to parse the same selector more than once.
         @parsed_selectors ||= {}

--- a/lib/kitchen/version.rb
+++ b/lib/kitchen/version.rb
@@ -3,5 +3,5 @@
 # A library for modifying the structure of OpenStax book XML.
 #
 module Kitchen
-  VERSION = '15.0.0'
+  VERSION = '16.0.0'
 end

--- a/spec/directions/bake_footnotes/v1_spec.rb
+++ b/spec/directions/bake_footnotes/v1_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe Kitchen::Directions::BakeFootnotes::V1 do
         <div data-type="page">
           <p><a href="#aside6" role="doc-noteref">[footnote]</a> Blah.</p>
           <aside id="aside6" type="footnote">Footnote content 6</aside>
+          <p><sup><a href="#aside9" role="doc-noteref">[footnote]</a> Blah.</sup></p>
+            <aside id="aside9" type="footnote">Footnote content 9</aside>
         </div>
       HTML
     )
@@ -83,6 +85,8 @@ RSpec.describe Kitchen::Directions::BakeFootnotes::V1 do
         <div data-type="page">
           <p class="has-noteref"><a href="#aside6" role="doc-noteref">1</a> Blah.</p>
           <aside id="aside6" type="footnote"><div data-type="footnote-number">1</div>Footnote content 6</aside>
+          <p class="has-noteref"><sup><a href="#aside9" role="doc-noteref">2</a> Blah.</sup></p>
+          <aside id="aside9" type="footnote"><div data-type="footnote-number">2</div>Footnote content 9</aside>
         </div>
       HTML
     )
@@ -126,6 +130,8 @@ RSpec.describe Kitchen::Directions::BakeFootnotes::V1 do
         <div data-type="page">
           <p class="has-noteref"><a href="#aside6" role="doc-noteref">i</a> Blah.</p>
           <aside id="aside6" type="footnote"><div data-type="footnote-number">i</div>Footnote content 6</aside>
+          <p class="has-noteref"><sup><a href="#aside9" role="doc-noteref">ii</a> Blah.</sup></p>
+          <aside id="aside9" type="footnote"><div data-type="footnote-number">ii</div>Footnote content 9</aside>
         </div>
       HTML
     )

--- a/spec/directions/bake_references/v1_spec.rb
+++ b/spec/directions/bake_references/v1_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe Kitchen::Directions::BakeReferences do
                 Reference 2
               </div>
             </a>
+            " However, in the 2018 midterm elections, an estimated 31 percent of Americans under thirty turned out to vote, the highest level of young adult engagement in decades."
+            <a href="#auto_54322" data-type="cite">
+              <div data-type="note" class="reference" display="inline" id="auto_54322">
+                Reference 3
+              </div>
+            </a>
           </p>
         </div>
       </div>
@@ -42,7 +48,7 @@ RSpec.describe Kitchen::Directions::BakeReferences do
           <p>
             <a href="#auto_6789" data-type="cite">
               <div data-type="note" class="reference" display="inline" id="auto_6789">
-                Reference 3
+                Reference 4
               </div>
             </a>
           </p>
@@ -79,10 +85,15 @@ RSpec.describe Kitchen::Directions::BakeReferences do
                 <a data-type="cite" href="#auto_12345">
                   <sup class="os-citation-number">1</sup>
                 </a>
+                <span class="os-reference-link-separator">, </span>
                 <a data-type="cite" href="#auto_54321">
                   <sup class="os-citation-number">2</sup>
                 </a>
-              </p>
+              " However, in the 2018 midterm elections, an estimated 31 percent of Americans under thirty turned out to vote, the highest level of young adult engagement in decades."
+              <a data-type="cite" href="#auto_54322">
+                <sup class="os-citation-number">3</sup>
+              </a>
+            </p>
             </div>
           </div>
           <div data-type="chapter">
@@ -133,13 +144,16 @@ RSpec.describe Kitchen::Directions::BakeReferences do
               <div class="reference" data-type="note" display="inline" id="auto_54321"><span class="os-reference-number">2. </span>
                   Reference 2
                 </div>
+              <div class="reference" data-type="note" display="inline" id="auto_54322"><span class="os-reference-number">3. </span>
+                  Reference 3
+                </div>
             </div>
             <div class="os-chapter-area">
               <h2 data-type="document-title">
                 <span class="os-text" data-type="" itemprop="">Title Text Chapter 2</span>
               </h2>
               <div class="reference" data-type="note" display="inline" id="auto_6789"><span class="os-reference-number">1. </span>
-                  Reference 3
+                  Reference 4
                 </div>
             </div>
           </div>


### PR DESCRIPTION
To deal with a redundancy discovered in #446 

There's a preexisting nokigiri method #previous_element that skips text and just returns an element-- so nokigiri#previous does not need to be patched like it is. The patched nokigiri#previous is only used in ElementBase#previous, so I've swapped that out for nokigiri#previous_element and there is no loss of functionality and no new bugs. #previous_element does not return text or blank spaces.