### PR TITLE
add method that generate roman numbers up to 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Create method in `Integer` class that generate roman numbers up to 100 (minor)
 * Add more roman numbers to `Integer` class (patch)
 * Create `V2` for `BakeChapterReferences` (minor)
 * Create `BakeExercisePrefixes` direction adding prefixes for exercises in selected sections (minor)

--- a/lib/kitchen/patches/integer.rb
+++ b/lib/kitchen/patches/integer.rb
@@ -3,10 +3,22 @@
 # Monkey patches for +Integer+
 #
 class Integer
-  ROMAN_NUMERALS = %w[0 i ii iii iv v vi vii viii ix
-                      x xi xii xiii xiv xv xvi xvii xviii xix
-                      xx xxi xxii xxiii xxiv xxv xxvi xxvii xxviii xxix
-                      xxx xxxi xxxii xxxiii xxxiv xxxv xxxvi xxxvii xxxviii xxxix].freeze
+
+  @roman_numerals = {
+    100 => 'c',
+    90 => 'xc',
+    50 => 'l',
+    40 => 'xl',
+    10 => 'x',
+    9 => 'ix',
+    5 => 'v',
+    4 => 'iv',
+    1 => 'i'
+  }
+
+  class << self
+    attr_accessor :roman_numerals
+  end
 
   # Formats as different types of integers, including roman numerals.
   #
@@ -17,11 +29,25 @@ class Integer
     when :arabic
       to_s
     when :roman
-      raise 'Unknown conversion to Roman numerals' if self >= ROMAN_NUMERALS.size
+      raise 'Unknown conversion to Roman numerals' if self > self.class.roman_numerals.keys.first
 
-      ROMAN_NUMERALS[self]
+      to_roman
     else
       raise 'Unknown integer format'
     end
+  end
+
+  def to_roman
+    return 0 if zero?
+
+    roman = ''
+    integer = self
+    self.class.roman_numerals.each do |number, letter|
+      until integer < number
+        roman += letter
+        integer -= number
+      end
+    end
+    roman
   end
 end

--- a/spec/integer_spec.rb
+++ b/spec/integer_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Integer do
     it 'converts to roman numerals' do
       expect(3.to_format(:roman)).to eq('iii')
       expect(20.to_format(:roman)).to eq('xx')
-      expect(33.to_format(:roman)).to eq('xxxiii')
+      expect(54.to_format(:roman)).to eq('liv')
       expect {
-        40.to_format(:roman)
+        101.to_format(:roman)
       }.to raise_error('Unknown conversion to Roman numerals')
     end
 

--- a/spec/integer_spec.rb
+++ b/spec/integer_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Integer do
 
     it 'converts to roman numerals' do
       expect(3.to_format(:roman)).to eq('iii')
-      expect(20.to_format(:roman)).to eq('xx')
       expect(54.to_format(:roman)).to eq('liv')
+      expect(96.to_format(:roman)).to eq('xcvi')
       expect {
         101.to_format(:roman)
       }.to raise_error('Unknown conversion to Roman numerals')


### PR DESCRIPTION
Done for Intellectual Property. This book has over 80 footnotes in roman numbers, so I added method that generate them rather then create bigger constant. I had problems with instance variable. Adding `attr_reader` or `attr_accesor` at the beginning of the class didn't help, methods from this class treated variable as nil. I found another solution, but if someone have better idea how to handle this let me know :wink: 