### PR TITLE
fix searching cases in target labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Fix problem with namespaces in `BakeLinkPlaceholders` (minor)
+* Fix problem with namespaces in `BakeLinkPlaceholders` and `BakeIndex` (minor)
 * Create `V3` for `BakeChapterReferences`  which sorts references alphabetically (minor)
 
 ## [17.0.0] - 2021-12-3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Fix problem with namespaces in `BakeLinkPlaceholders` (minor)
 * Create `V3` for `BakeChapterReferences`  which sorts references alphabetically (minor)
 
 ## [17.0.0] - 2021-12-3

--- a/lib/kitchen/directions/bake_index/v1.rb
+++ b/lib/kitchen/directions/bake_index/v1.rb
@@ -154,14 +154,14 @@ module Kitchen::Directions::BakeIndex
       type =
         if !term_element.key?('index')
           'term'
-        elsif term_element['cxlxt:index'] == 'name'
+        elsif term_element['cxlxt:index'] == 'name' || term_element['index'] == 'name'
           'name'
-        elsif term_element['cxlxt:index'] == 'foreign'
+        elsif term_element['cxlxt:index'] == 'foreign' || term_element['index'] == 'foreign'
           'foreign'
         end
 
       if term_element.key?('reference')
-        term_reference = term_element['cmlnle:reference']
+        term_reference = term_element['cmlnle:reference'] || term_element['reference']
         group_by = term_reference[0]
         content = term_reference
       else

--- a/lib/kitchen/directions/bake_link_placeholders.rb
+++ b/lib/kitchen/directions/bake_link_placeholders.rb
@@ -9,7 +9,7 @@ module Kitchen
         book.search('a').each do |anchor|
           next unless anchor.text == '[link]'
 
-          label_case = anchor['cmlnle:case']
+          label_case = anchor['cmlnle:case'] || anchor['case']
           id = anchor[:href][1..-1]
 
           if cases

--- a/spec/directions/bake_index/v1_context2_spec.rb
+++ b/spec/directions/bake_index/v1_context2_spec.rb
@@ -54,6 +54,11 @@ RSpec.describe Kitchen::Directions::BakeIndex do
             <span data-type="foreign" xml:lang="en">
               <span xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" data-type="term" cxlxt:index="foreign"><em>sp</em><sup>3</sup><em>d</em><sup>2</sup> orbitals</span>
             </span>
+            <span data-type="term" reference="bar">Boo</span>
+            <span data-type="term" reference="Christmas, Mary (ur. 1958)" index="name" name="Christmas, Mary" born="1958">Mary Christmas</span>
+            <span data-type="foreign" xml:lang="en">
+              <span data-type="term" index="foreign">train</span>
+            </span>
           </div>
           <div data-type="composite-chapter">
             <div data-type="document-title">Chapter Review</div>
@@ -116,6 +121,11 @@ RSpec.describe Kitchen::Directions::BakeIndex do
                 <span data-type="foreign" xml:lang="en">
                   <span xmlns:cxlxt="http://katalysteducation.org/cxlxt/1.0" data-type="term" cxlxt:index="foreign" id="auto_p2_term13" group-by="s"><em>sp</em><sup>3</sup><em>d</em><sup>2</sup> orbitals</span>
                 </span>
+                <span data-type="term" reference="bar" id="auto_p2_term14" group-by="b">Boo</span>
+                <span data-type="term" reference="Christmas, Mary (ur. 1958)" index="name" name="Christmas, Mary" born="1958" id="auto_p2_term15" group-by="C">Mary Christmas</span>
+                <span data-type="foreign" xml:lang="en">
+                  <span data-type="term" index="foreign" id="auto_p2_term16" group-by="t">train</span>
+                </span>
               </div>
               <div data-type="composite-chapter">
                 <div data-type="document-title">Chapter Review</div>
@@ -157,6 +167,14 @@ RSpec.describe Kitchen::Directions::BakeIndex do
                     -->
                   <span class="os-index-link-separator">, </span>
                   <a class="os-term-section-link" href="#auto_p2_term11">
+                    <span class="os-term-section">1.1 First Page</span>
+                  </a>
+                  <!--
+                    -->
+                </div>
+                <div class="os-index-item">
+                  <span class="os-term" group-by="C">Christmas, Mary (ur. 1958)</span>
+                  <a class="os-term-section-link" href="#auto_p2_term15">
                     <span class="os-term-section">1.1 First Page</span>
                   </a>
                   <!--
@@ -205,6 +223,17 @@ RSpec.describe Kitchen::Directions::BakeIndex do
                 <div class="os-index-item">
                   <span class="os-term" group-by="a">animag</span>
                   <a class="os-term-section-link" href="#auto_p2_term7">
+                    <span class="os-term-section">1.1 First Page</span>
+                  </a>
+                  <!--
+                    -->
+                </div>
+              </div>
+              <div class="group-by">
+                <span class="group-label">B</span>
+                <div class="os-index-item">
+                  <span class="os-term" group-by="b">bar</span>
+                  <a class="os-term-section-link" href="#auto_p2_term14">
                     <span class="os-term-section">1.1 First Page</span>
                   </a>
                   <!--
@@ -312,6 +341,17 @@ RSpec.describe Kitchen::Directions::BakeIndex do
                 <div class="os-index-item">
                   <span class="os-term" group-by="s">sp3d2 orbitals</span>
                   <a class="os-term-section-link" href="#auto_p2_term13">
+                    <span class="os-term-section">1.1 First Page</span>
+                  </a>
+                  <!--
+                    -->
+                </div>
+              </div>
+              <div class="group-by">
+                <span class="group-label">T</span>
+                <div class="os-index-item">
+                  <span class="os-term" group-by="t">train</span>
+                  <a class="os-term-section-link" href="#auto_p2_term16">
                     <span class="os-term-section">1.1 First Page</span>
                   </a>
                   <!--

--- a/spec/directions/bake_link_placeholders_spec.rb
+++ b/spec/directions/bake_link_placeholders_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Kitchen::Directions::BakeLinkPlaceholders do
         <a>skip this link</a>
         <a href='?other_key'>[link]</a>
         <a xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" cmlnle:case="genitive" href='?other_key'>[link]</a>
+        <a case="locative" href='?next_key'>[link]</a>
       HTML
     )
   end
@@ -53,6 +54,7 @@ RSpec.describe Kitchen::Directions::BakeLinkPlaceholders do
     before do
       book_with_cases.pantry(name: :nominative_link_text).store('Przykład x.y', label: 'other_key')
       book_with_cases.pantry(name: :genitive_link_text).store('Przykładu x.y', label: 'other_key')
+      book_with_cases.pantry(name: :locative_link_text).store('Przykładzie x.y', label: 'next_key')
     end
 
     it 'bakes' do
@@ -63,6 +65,7 @@ RSpec.describe Kitchen::Directions::BakeLinkPlaceholders do
             <a>skip this link</a>
             <a href='?other_key'>Przykład x.y</a>
             <a xmlns:cmlnle="http://katalysteducation.org/cmlnle/1.0" cmlnle:case="genitive" href='?other_key'>Przykładu x.y</a>
+            <a case="locative" href='?next_key'>Przykładzie x.y</a>
           </body>
         HTML
       )


### PR DESCRIPTION
Done for Polish U-Physics.

After moving sections to EOC target labels are loosing `cmlnle` part of attribute.