### PR TITLE
remove additional title from Answer Key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Create `AnswerKeyCleaner` to remove empty chapter containers (minor)
 * Change markup to `span` with `sup` for reference link separator `BakeReferences.v1` plus remove whitespaces and new lines (patch)
 * Changes to `BakeScreenreaderSpans` behavior (major)
 * Changes to `BakeToc` to improve error messaging by including `page.id` (minor)

--- a/lib/kitchen/directions/move_solutions_to_answer_key/answer_key_cleaner.rb
+++ b/lib/kitchen/directions/move_solutions_to_answer_key/answer_key_cleaner.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Kitchen::Directions::AnswerKeyCleaner
+  def self.v1(book:)
+    V1.new.bake(book: book)
+  end
+
+  class V1
+    renderable
+
+    def bake(book:)
+      answer_key_chapters = book.search(
+        '.os-eob[data-type="composite-chapter"] > [data-type="composite-page"]')
+      answer_key_chapters.each do |container|
+        container.trash unless container.contains?('[data-type="solution"]')
+      end
+    end
+  end
+end

--- a/spec/directions/move_solutions_to_answer_key/answer_key_cleaner_spec.rb
+++ b/spec/directions/move_solutions_to_answer_key/answer_key_cleaner_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Kitchen::Directions::AnswerKeyCleaner do
+  let(:book) do
+    book_containing(html:
+      <<~HTML
+        <div class="os-eob os-solution-container" data-type="composite-chapter">
+          <h1 data-type="document-title" id="composite-chapter-1">
+            <span class="os-text">Answer Key</span>
+          </h1>
+          <div class="os-eob os-solution-container" data-type="composite-page">
+            <h2 data-type="document-title">
+              <span class="os-text">Chapter 1</span>
+            </h2>
+            <div data-type="solution" id="sol1">
+              <a class="os-number" href="#something">1</a>
+              <span class="os-divider">. </span>
+              <div class="os-solution-container">
+                <p>D</p>
+              </div>
+            </div>
+            <div data-type="solution" id="sol2">
+              <a class="os-number" href="#something">2</a>
+              <span class="os-divider">. </span>
+              <div class="os-solution-container">
+                <p>A</p>
+              </div>
+            </div>
+            <div data-type="solution" id="sol3">
+              <a class="os-number" href="#something">3</a>
+              <span class="os-divider">. </span>
+              <div class="os-solution-container">
+                <p>C</p>
+              </div>
+            </div>
+          </div>
+          <div class="os-eob os-solution-container" data-type="composite-page">
+            <h2 data-type="document-title">
+              <span class="os-text">Chapter 2</span>
+            </h2>
+          </div>
+        </div>
+      HTML
+    )
+  end
+
+  it 'removes container without solutions' do
+    described_class.v1(book: book)
+    expect(book.first('.os-eob[data-type="composite-chapter"]').to_s).to match_normalized_html(
+      <<~HTML
+        <div class="os-eob os-solution-container" data-type="composite-chapter">
+          <h1 data-type="document-title" id="composite-chapter-1">
+            <span class="os-text">Answer Key</span>
+          </h1>
+          <div class="os-eob os-solution-container" data-type="composite-page">
+            <h2 data-type="document-title">
+              <span class="os-text">Chapter 1</span>
+            </h2>
+            <div data-type="solution" id="sol1">
+              <a class="os-number" href="#something">1</a>
+              <span class="os-divider">. </span>
+              <div class="os-solution-container">
+                <p>D</p>
+              </div>
+            </div>
+            <div data-type="solution" id="sol2">
+              <a class="os-number" href="#something">2</a>
+              <span class="os-divider">. </span>
+              <div class="os-solution-container">
+                <p>A</p>
+              </div>
+            </div>
+            <div data-type="solution" id="sol3">
+              <a class="os-number" href="#something">3</a>
+              <span class="os-divider">. </span>
+              <div class="os-solution-container">
+                <p>C</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      HTML
+    )
+  end
+end


### PR DESCRIPTION
Issue: https://github.com/openstax/cnx-recipes/issues/3046

Problem appears because first we are creating chapter containers (for all chapters), then we're moving solutions to them in a separate method:

![image](https://user-images.githubusercontent.com/40228854/151136787-6e6db43e-fc50-45f9-bedd-d13bdb76cb4b.png)

It's hard to combine these two methods and make chapter containers to be depended of existance of solutions, because containers (and whole Answer Key) is created at the end of book, not within chapter, and because books are using different strategies, so change should be done for each strategy separately. That's why I decided to create new method which should be run at the end of `bake` file. It cleans all additional chapters containers, after entire Answer Key is created. Let me know what do you thing :wink: 